### PR TITLE
Table ACLs tested --table-acls  --debug

### DIFF
--- a/data/aws_cluster_table_acls.json
+++ b/data/aws_cluster_table_acls.json
@@ -5,7 +5,9 @@
   "spark_conf": {
     "spark.databricks.cluster.profile": "serverless",
     "spark.databricks.repl.allowedLanguages": "python,sql",
-    "spark.databricks.acl.dfAclsEnabled": "true"
+    "spark.databricks.acl.dfAclsEnabled": "true",
+    "spark.sql.hive.metastore.version": "1.2.1",
+    "spark.sql.hive.metastore.jars": "maven"
   },
   "aws_attributes": {
     "first_on_demand": 1,

--- a/data/notebooks/Export_Table_ACLs.py
+++ b/data/notebooks/Export_Table_ACLs.py
@@ -7,17 +7,52 @@
 # MAGIC - Databases: [Optional] comma separated list of databases to be exported, if empty all databases will be exported
 # MAGIC - OutputPath: Path to write the exported file to 
 # MAGIC 
+# MAGIC Returns: (`dbutils.notebook.exit(exit_JSON_string)`)
+# MAGIC - `{ "total_num_acls": <int>, "num_errors": <int> }` 
+# MAGIC   - total_num_acls : valid ACL entries int the exported JSON
+# MAGIC   - num_errors : error entries in the exported JSON, principal is set to `ERROR_!!!` and object_key and object_value are prefixed with `ERROR_!!!`
+# MAGIC 
 # MAGIC Execution: **Run the notebook on a cluster with Table ACL's enabled as a user who is an admin** 
 # MAGIC 
-# MAGIC Supportes ACLs for Object types:
+# MAGIC Supported object types:
 # MAGIC - Catalog: included if all databases are exported, not included if databases to be exported are specified
 # MAGIC   - Database: included
 # MAGIC     - Table: included
-# MAGIC     - View: included
+# MAGIC     - View: included (they are treated as tables with ObjectType `TABLE`)
 # MAGIC - Anonymous Function: included (testing pending)
 # MAGIC - Any File: included
 # MAGIC 
-# MAGIC Disclaimer: This notebook is still needs some more testing, check back soon as fixes might have been added.
+# MAGIC Unsupported object types:
+# MAGIC - User Function: Currently in Databricks SQL not supported - will add support later
+# MAGIC 
+# MAGIC JSON File format: Line of JSON objects, gzipped
+# MAGIC 
+# MAGIC - written as `.coalesce(1).format("JSON").option("compression","gzip")`
+# MAGIC - each line contains a JSON object with the keys:
+# MAGIC   - `Database`: string
+# MAGIC   - `Principal`: string
+# MAGIC   - `ActionTypes`: list of action strings: 
+# MAGIC   - `ObjectType`: `(ANONYMOUS_FUNCTION|ANY_FILE|CATALOG$|DATABASE|TABLE|ERROR_!!!_<type>)` (view are treated as tables)
+# MAGIC   - `ObjectKey`: string
+# MAGIC   - `ExportTimestamp`: string
+# MAGIC - error lines contains:
+# MAGIC   - the special `Principal` `ERROR_!!!` 
+# MAGIC   - `ActionTypes` contains one element: the error message, starting with `ERROR!!! :`
+# MAGIC   - `Database`, `ObjectType`, `ObjectKey` are all prefixed with `ERROR_!!!_`
+# MAGIC - error lines are ignored by the Import_Table_ACLs 
+# MAGIC 
+# MAGIC The JSON file is written as table, because on a cluster with Table ACLS activated, files cannot be written directly.
+# MAGIC The output path will contain other files and diretories, starting with `_`, which can be ignored.
+# MAGIC 
+# MAGIC 
+# MAGIC What to do if exported JSON contains errors (the notebook returns `num_errors` > 0):
+# MAGIC - If there are only a few errors ( e.g. less then 1% or less then dozen)
+# MAGIC   - proceed with the import (any error lines will be ignored)
+# MAGIC   - For each error, the object type, name and error message is included so the cause can be investigated
+# MAGIC     - in most cases, it turns out that those are broken or not used tables or views
+# MAGIC - If there are many errors
+# MAGIC   - Try executing some `SHOW GRANT` commands on the same cluster using the same user, there might be a underlying problem
+# MAGIC   - review the errors and investiage
 
 # COMMAND ----------
 
@@ -39,7 +74,35 @@ if not dbutils.widgets.get("OutputPath").startswith("dbfs:/"):
 # DBTITLE 1,Define Export Logic
 import pyspark.sql.functions as sf
 from typing import Callable, Iterator, Union, Optional, List
-import datetime;
+import datetime
+import sys
+
+def create_error_grants_df(sys_exec_info_res, database_name: str,object_type: str, object_key: str):
+  msg_context = f"context: database_name: {database_name}, object_type: {object_type}, object_key: {object_key}"
+
+  msg_lines = str(sys_exec_info_res[1]).split("\n")
+  if len(msg_lines) <= 2:
+    short_message = " ".join(msg_lines)
+  else:
+    short_message = " ".join(msg_lines[:2])   
+  error_message = f"ERROR!!! : exception class {sys_exec_info_res[0]},  message: {short_message}, {msg_context}".replace('"',"'")
+
+  print(error_message)
+
+  database_value = f"'ERROR_!!!_{database_name}'".replace('"',"'") if database_name else "NULL"
+  object_key_value = f"'ERROR_!!!_{object_key}'".replace('"',"'") if object_key else "NULL"
+  object_type_value = f"'ERROR_!!!_{object_type}'".replace('"',"'") if object_type else "NULL" # Import ignores this object type
+
+  grants_df = spark.sql(f"""SELECT 
+      {database_value} AS Database, 
+      'ERROR_!!!' AS Principal,
+      array("{error_message}") AS ActionTypes, 
+      {object_type_value} AS ObjectType, 
+      {object_key_value} AS ObjectKey, 
+      Now() AS ExportTimestamp
+   """)  
+
+  return grants_df
 
 def get_database_names():
   database_names = []
@@ -50,20 +113,24 @@ def get_database_names():
       database_names.append(db.namespace)
   return database_names
 
-def create_grants_df(database_name: str,object_type: str, object_key: str) -> List[str]:
-  if object_type in ["CATALOG", "ANY FILE", "ANONYMOUS FUNCTION"]: #without object key
-     grants_df = (
-       spark.sql(f"SHOW GRANT ON {object_type}")
-       .groupBy("ObjectType","ObjectKey","Principal").agg(sf.collect_set("ActionType").alias("ActionTypes"))
-       .selectExpr("NULL AS Database","Principal","ActionTypes","ObjectType","ObjectKey","Now() AS ExportTimestamp")
-     )
-  else: 
-    grants_df = (
-      spark.sql(f"SHOW GRANT ON {object_type} {object_key}")
-      .filter(sf.col("ObjectType") == f"{object_type}")
-      .groupBy("ObjectType","ObjectKey","Principal").agg(sf.collect_set("ActionType").alias("ActionTypes"))
-      .selectExpr(f"'{database_name}' AS Database","Principal","ActionTypes","ObjectType","ObjectKey","Now() AS ExportTimestamp")
-    )  
+def create_grants_df(database_name: str,object_type: str, object_key: str):
+  try:
+    if object_type in ["CATALOG", "ANY FILE", "ANONYMOUS FUNCTION"]: #without object key
+       grants_df = (
+         spark.sql(f"SHOW GRANT ON {object_type}")
+         .groupBy("ObjectType","ObjectKey","Principal").agg(sf.collect_set("ActionType").alias("ActionTypes"))
+         .selectExpr("NULL AS Database","Principal","ActionTypes","ObjectType","ObjectKey","Now() AS ExportTimestamp")
+       )
+    else: 
+      grants_df = (
+        spark.sql(f"SHOW GRANT ON {object_type} {object_key}")
+        .filter(sf.col("ObjectType") == f"{object_type}")
+        .groupBy("ObjectType","ObjectKey","Principal").agg(sf.collect_set("ActionType").alias("ActionTypes"))
+        .selectExpr(f"'{database_name}' AS Database","Principal","ActionTypes","ObjectType","ObjectKey","Now() AS ExportTimestamp")
+      )  
+  except:  
+    grants_df = create_error_grants_df(sys.exc_info(), database_name, object_type, object_key)
+    
   return grants_df
   
 
@@ -77,6 +144,9 @@ def create_table_ACLSs_df_for_databases(database_names: List[str]):
     include_catalog = True
   else:
     include_catalog = False
+    
+  num_databases_processed = len(database_names)
+  num_tables_or_views_processed = 0
 
   # ANONYMOUS FUNCTION
   combined_grant_dfs = create_grants_df(None, "ANONYMOUS FUNCTION", None)
@@ -100,25 +170,32 @@ def create_table_ACLSs_df_for_databases(database_names: List[str]):
       create_grants_df(database_name, "DATABASE", database_name)
     )
     
-    tables_and_views_rows = spark.sql(
-      f"SHOW TABLES IN {database_name}"
-    ).filter(sf.col("isTemporary") == False).collect()
-    
-    print(f"{datetime.datetime.now()} working on database {database_name} with {len(tables_and_views_rows)} tables and views")
-    for table_row in tables_and_views_rows:
-      
-      # TABLE, VIEW
+    try:
+      tables_and_views_rows = spark.sql(
+        f"SHOW TABLES IN {database_name}"
+      ).filter(sf.col("isTemporary") == False).collect()
+
+      print(f"{datetime.datetime.now()} working on database {database_name} with {len(tables_and_views_rows)} tables and views")
+      num_tables_or_views_processed = num_tables_or_views_processed + len(tables_and_views_rows)
+     
+      for table_row in tables_and_views_rows:
+
+        # TABLE, VIEW
+        combined_grant_dfs = combined_grant_dfs.unionAll(
+          create_grants_df(database_name, "TABLE", f"{table_row.database}.{table_row.tableName}")
+        )
+    except:  
+      # error in SHOW TABLES IN database_name, errors in create_grants_df have already been catched
       combined_grant_dfs = combined_grant_dfs.unionAll(
-        create_grants_df(database_name, "TABLE", f"{table_row.database}.{table_row.tableName}")
+        create_error_grants_df(sys.exc_info(), database_name ,"DATABASE", database_name)
       )
-   
+      
+     
     #TODO ADD USER FUNCTION - not supported in SQL Analytics, so this can wait a bit
     # ... SHOW USER FUNCTIONS LIKE  <my db>.`*`;
     #. function_row['function']   ... nah does not seem to work
-    
-  #combined_grant_dfs = combined_grant_dfs.sort("")
-      
-  return combined_grant_dfs
+          
+  return combined_grant_dfs, num_databases_processed, num_tables_or_views_processed
 
 
 # COMMAND ----------
@@ -135,8 +212,9 @@ else:
   print(f"Exporting the following databases: {databases}")
 
 
-table_ACLs_df = create_table_ACLSs_df_for_databases(databases)
+table_ACLs_df,num_databases_processed, num_tables_or_views_processed = create_table_ACLSs_df_for_databases(databases)
 
+print(f"{datetime.datetime.now()} total number processed: databases: {num_databases_processed}, tables or views: {num_tables_or_views_processed}")
 print(f"{datetime.datetime.now()} writing table ACLs to {output_path}")
 
 # with table ACLS active, I direct write to DBFS is not allowed, so we store
@@ -156,11 +234,35 @@ print(f"{datetime.datetime.now()} writing table ACLs to {output_path}")
 
 # COMMAND ----------
 
+# DBTITLE 1,Exported Table ACLs
 display(spark.read.format("json").load(output_path)) 
 
 # COMMAND ----------
 
 print(output_path)
+
+# COMMAND ----------
+
+# DBTITLE 1,Write total_num_acls and num_errors to the notebook exit value
+totals_df = (spark.read
+      .format("JSON")
+      .load(output_path)
+      .selectExpr(
+         "sum(1) AS total_num_acls"
+        ,"sum(CASE WHEN Principal = 'ERROR_!!!' THEN 1 ELSE 0 END) AS num_errors")
+     )
+
+res_rows = totals_df.collect()
+
+exit_JSON_string = '{ "total_num_acls": '+str(res_rows[0]["total_num_acls"])+', "num_errors": '+str(res_rows[0]["num_errors"])+' }'
+
+print(exit_JSON_string)
+
+dbutils.notebook.exit(exit_JSON_string) 
+
+# COMMAND ----------
+
+
 
 # COMMAND ----------
 

--- a/data/notebooks/Import_Table_ACLs.py
+++ b/data/notebooks/Import_Table_ACLs.py
@@ -5,18 +5,54 @@
 # MAGIC 
 # MAGIC Parameters:
 # MAGIC - InputPath: Path to the JSON file to import from (gzipped JSON) 
+# MAGIC Returns: (`dbutils.notebook.exit(exit_JSON_string)`)
+# MAGIC - `{ "total_num_acls": <int>, "num_sucessfully_executed": <int>, "num_execution_errors": <int>, , "num_error_entries_acls": <int> }` 
+# MAGIC   - total_num_acls : ACL entries sucessfully executed
+# MAGIC   - num_sucessfully_executed : ACL entries sucessfully executed
+# MAGIC   - num_execution_errors : valid ACL entries that caused an error when executing
+# MAGIC   - num_error_entries_acls : error entries in the imported JSON ignored, principal is set to `ERROR_!!!` and object_key and object_value are prefixed with `ERROR_!!!`
 # MAGIC 
 # MAGIC Execution: **Run the notebook on a cluster with Table ACL's enabled as a user who is an admin** 
 # MAGIC 
-# MAGIC Supportes ACLs for Object types:
+# MAGIC Supported object types:
 # MAGIC - Catalog: included if all databases are exported, not included if databases to be exported are specified
 # MAGIC   - Database: included
 # MAGIC     - Table: included
-# MAGIC     - View: included
+# MAGIC     - View: (they are treated as tables with ObjectType `TABLE`)
 # MAGIC - Anonymous Function: included (testing pending)
 # MAGIC - Any File: included
 # MAGIC 
-# MAGIC Disclaimer: This notebook is still needs some more testing, check back soon as fixes might have been added.
+# MAGIC Unsupported object types:
+# MAGIC - User Function: Currently in Databricks SQL not supported - will add support later
+# MAGIC 
+# MAGIC JSON File format: Line of JSON objects, gzipped
+# MAGIC 
+# MAGIC - written as `.coalesce(1).format("JSON").option("compression","gzip")`
+# MAGIC - each line contains a JSON object with the keys:
+# MAGIC   - `Database`: string
+# MAGIC   - `Principal`: string
+# MAGIC   - `ActionTypes`: list of action strings: 
+# MAGIC   - `ObjectType`: `(ANONYMOUS_FUNCTION|ANY_FILE|CATALOG$|DATABASE|TABLE|ERROR_!!!_<type>)` (view are treated as tables)
+# MAGIC   - `ObjectKey`: string
+# MAGIC   - `ExportTimestamp`: string
+# MAGIC - error lines contains:
+# MAGIC   - the special `Principal` `ERROR_!!!` 
+# MAGIC   - `ActionTypes` contains one element: the error message, starting with `ERROR!!! :`
+# MAGIC   - `Database`, `ObjectType`, `ObjectKey` are all prefixed with `ERROR_!!!_`
+# MAGIC - error lines are ignored by the Import_Table_ACLs 
+# MAGIC 
+# MAGIC The JSON file is written as table, because on a cluster with Table ACLS activated, files cannot be written directly.
+# MAGIC The output path will contain other files and diretories, starting with `_`, which can be ignored.
+# MAGIC 
+# MAGIC 
+# MAGIC What to do if exported JSON contains errors (the notebook returns `num_errors` > 0):
+# MAGIC - If there are only a few errors ( e.g. less then 1% or less then dozen)
+# MAGIC   - proceed with the import (any error lines will be ignored)
+# MAGIC   - For each error, the object type, name and error message is included so the cause can be investigated
+# MAGIC     - in most cases, it turns out that those are broken or not used tables or views
+# MAGIC - If there are many errors
+# MAGIC   - Try executing some `SHOW GRANT` commands on the same cluster using the same user, there might be a underlying problem
+# MAGIC   - review the errors and investiage
 
 # COMMAND ----------
 
@@ -41,7 +77,8 @@ display(spark.read.format("JSON").load(dbutils.widgets.get("InputPath")))
 import datetime
 import pyspark.sql.functions as sf
 from typing import Callable, Iterator, Union, Optional, List
-
+import sys
+import json
 
 def generate_table_acls_command(action_types, object_type, object_key, principal, alter_owner=True):
   lines = []
@@ -65,6 +102,8 @@ def generate_table_acls_command(action_types, object_type, object_key, principal
 
 def generate_table_acls_commands(table_ACLs_df, commented: bool=True, alter_owner: bool=True) -> List[str]:
   lines = []
+  total_num_acls = 0
+  num_error_entries_acls = 0
   for row in table_ACLs_df.collect():
     
     
@@ -78,15 +117,31 @@ def generate_table_acls_commands(table_ACLs_df, commented: bool=True, alter_owne
       # DATABASE, TABLE, VIEW (view's seem to show up as tables)
       lines.extend(generate_table_acls_command(row['ActionTypes'], row['ObjectType'], row['ObjectKey'], row['Principal'], alter_owner))
     # TODO ADD   USER FUNCTION .. need to figure out
+    
+    if row["Principal"] == "ERROR_!!!":
+      num_error_entries_acls = num_error_entries_acls + 1
+    else
+      total_num_acls = total_num_acls + 1
+   
       
-  return lines
+  return lines, total_num_acls, num_error_entries_acls
 
 def execute_sql_statements(sqls):
+  num_sucessfully_executed = 0
+  num_execution_errors = 0
+  error_causing_sqls = []
   for sql in sqls.split(sep=";"):
     sql = sql.strip()
     if sql:
       print(f"{sql};")
-      spark.sql(sql)
+      try:
+        spark.sql(sql)
+        num_sucessfully_executed = num_sucessfully_executed+1
+      except:
+        error_causing_sqls.append({'sql': sql, 'error': sys.exc_info()})
+        num_execution_errors = num_execution_errors+1
+      
+  return num_sucessfully_executed, num_execution_errors, error_causing_sqls
 
       
 
@@ -101,15 +156,43 @@ table_ACLs_df = spark.read.format("JSON").load(input_path).orderBy("Database","O
 print(f"{datetime.datetime.now()} reading table ACLs from {input_path}")
 
 
-lines = generate_table_acls_commands(table_ACLs_df, commented=True, alter_owner=True)
+lines, total_num_acls, num_error_entries_acls = generate_table_acls_commands(table_ACLs_df, commented=True, alter_owner=True)
 
 sql="\n".join(lines)
 
 print(f"Number of table ACLs statements to execute: {len(lines)}")
 print("\n\n")
 
-execute_sql_statements(sql)
+num_sucessfully_executed, num_execution_errors, error_causing_sqls = execute_sql_statements(sql)
+
+#Returns: (`dbutils.notebook.exit(exit_JSON_string)`)
+#- `{ "total_num_acls": <int>, "num_sucessfully_executed": <int>, "num_execution_errors": <int>, , "num_error_entries_acls": <int> }` 
+#  - total_num_acls : ACL entries sucessfully executed
+#  - num_sucessfully_executed : ACL entries sucessfully executed
+#  - num_execution_errors : valid ACL entries that caused an error when executing
+#  - num_error_entries_acls : error entries in the imported JSON ignored, principal is set to `ERROR_!!!` and object_key and object_value are prefixed with `ERROR_!!!`
+
+exit_JSON_string = f'''{ 
+  "total_num_acls":  {total_num_acls}
+  ,"num_sucessfully_executed": {num_sucessfully_executed}
+  ,"num_execution_errors": {num_execution_errors}
+  ,"num_error_entries_acls": {num_error_entries_acls}
+}'''
+
 
 # COMMAND ----------
 
+# DBTITLE 1,Error causing SQL messages and error messages:
+if len(num_error_entries_acls) == 0:
+  print("No SQL errors")
+else:
+  print(f"Number of SQL errors: {len(num_error_entries_acls)}\n\n")
+  print(json.dumps(num_error_entries_acls, indent=2))
 
+# COMMAND ----------
+
+# DBTITLE 1,Write the notebook exit JSON string value
+
+print(exit_JSON_string)
+
+dbutils.notebook.exit(exit_JSON_string) 

--- a/data/notebooks/Import_Table_ACLs.py
+++ b/data/notebooks/Import_Table_ACLs.py
@@ -120,7 +120,7 @@ def generate_table_acls_commands(table_ACLs_df, commented: bool=True, alter_owne
     
     if row["Principal"] == "ERROR_!!!":
       num_error_entries_acls = num_error_entries_acls + 1
-    else
+    else:
       total_num_acls = total_num_acls + 1
    
       
@@ -172,22 +172,24 @@ num_sucessfully_executed, num_execution_errors, error_causing_sqls = execute_sql
 #  - num_execution_errors : valid ACL entries that caused an error when executing
 #  - num_error_entries_acls : error entries in the imported JSON ignored, principal is set to `ERROR_!!!` and object_key and object_value are prefixed with `ERROR_!!!`
 
-exit_JSON_string = f'''{ 
+exit_JSON_string = f"""{{ 
   "total_num_acls":  {total_num_acls}
   ,"num_sucessfully_executed": {num_sucessfully_executed}
   ,"num_execution_errors": {num_execution_errors}
   ,"num_error_entries_acls": {num_error_entries_acls}
-}'''
+}}"""
 
 
 # COMMAND ----------
 
 # DBTITLE 1,Error causing SQL messages and error messages:
-if len(num_error_entries_acls) == 0:
+if len(error_causing_sqls) == 0:
   print("No SQL errors")
 else:
-  print(f"Number of SQL errors: {len(num_error_entries_acls)}\n\n")
-  print(json.dumps(num_error_entries_acls, indent=2))
+  print(f"Number of SQL errors: {len(error_causing_sqls)}\n\n")
+  l = [ str(o) for o in error_causing_sqls ]
+  print("\n".join(l))
+
 
 # COMMAND ----------
 

--- a/dbclient/TableACLsClient.py
+++ b/dbclient/TableACLsClient.py
@@ -1,7 +1,7 @@
 from .ClustersClient import *
 import base64
 import shutil
-
+import json
 
 # noinspection SpellCheckingInspection
 
@@ -198,7 +198,7 @@ class TableACLsClient(ClustersClient):
             }
             res = self.get('/jobs/runs/get-output', runs_submit_params, print_json=True)
             if 'notebook_output' in res and 'result' in res['notebook_output']:
-                notebook_exit_value = res['notebook_output']['result']
+                notebook_exit_value = json.loads(res['notebook_output']['result'])
                 print(f'Successfull notebook run with notebook_output: {json.dumps(notebook_exit_value)}')
             else:
                 print(f'Successfull notebook run without notebook_output')

--- a/export_db.py
+++ b/export_db.py
@@ -3,7 +3,7 @@ from timeit import default_timer as timer
 from datetime import timedelta, datetime
 import os
 import shutil
-
+import json
 
 # python 3.6
 def main():
@@ -158,12 +158,20 @@ def main():
         table_acls_c = TableACLsClient(client_config)
         if args.database is not None:
             # export table ACLs only for a single database
-            table_acls_c.export_table_acls(db_name=args.database)
+            notebook_exit_value = table_acls_c.export_table_acls(db_name=args.database)
         else:
             # export table ACLs only for all databases
-            table_acls_c.export_table_acls(db_name='')
+            notebook_exit_value= table_acls_c.export_table_acls(db_name='')
         end = timer()
-        print("Complete Table ACL Export Time: " + str(timedelta(seconds=end - start)))
+        if notebook_exit_value['num_errors'] == 0:
+            print("Complete Table ACL Export Time: " + str(timedelta(seconds=end - start)))
+        elif notebook_exit_value['num_errors'] == -1:
+            print("Internal Notebook error, while executing  ACL Export , Time: " + str(timedelta(seconds=end - start)))
+        else:
+            print("Errors while exporting ACLs, some object's ACLs will be skipped  "
+                  + "(those objects ACL's will be ignored,they are documented with prefix 'ERROR_!!!'), "
+                  + f'notebook output: {json.dumps(notebook_exit_value)}, Table ACL Export Time: '
+                  + str(timedelta(seconds=end - start)))
 
     if args.secrets:
         if not args.cluster_name:

--- a/import_db.py
+++ b/import_db.py
@@ -2,6 +2,7 @@ from dbclient import *
 from timeit import default_timer as timer
 from datetime import timedelta, datetime
 from os import makedirs
+import json
 
 
 # python 3.6
@@ -120,9 +121,9 @@ def main():
         start = timer()
         table_acls_c = TableACLsClient(client_config)
         # log table ACLS configs
-        table_acls_c.import_table_acls()
+        notebook_exit_value = table_acls_c.import_table_acls()
         end = timer()
-        print("Complete Table ACLs Import Time: " + str(timedelta(seconds=end - start)))
+        print(f'Complete Table ACLs with exit value: {json.dumps(notebook_exit_value)}, Import Time: {timedelta(seconds=end - start)}')
 
     if args.pause_all_jobs:
         print("Pause all current jobs {0}".format(now))


### PR DESCRIPTION
Made Table ACLs export work on demo.cloud.databricks.com --table-acls  --debug
- most changes were done to the notebooks: added exception handling to SQL GRANTS
- added JSON result to notebooks and display in export and import calls
- added retry logic to notebook job run polling, as it would at times die
- import has just been done to e2-demo-migrate-dst.cloud.databricks.com - SQL GRANTS fail, but execute correct otherwise
- added much more detailed docu directly inside the notebooks - they can be used stand alone
- docu for readme not added yet, it will be mostly I shortened version of the docu I added to the notebooks (cell1)