### PR TITLE
Include cluster libraries with --libs export

### DIFF
--- a/export_db.py
+++ b/export_db.py
@@ -92,6 +92,7 @@ def main():
             lib_c = LibraryClient(client_config)
             start = timer()
             lib_c.log_library_details()
+            lib_c.log_cluster_libs()
             end = timer()
             print("Complete Library Download Time: " + str(timedelta(seconds=end - start)))
 


### PR DESCRIPTION
Even though we have a function to export cluster libraries, it was never called in `export_db.py`

https://github.com/databrickslabs/migrate/blob/7d525a431fb49dd9cee574217dd6022f3ac08d49/dbclient/LibraryClient.py#L24

**Testing:**
Manually tested by running `python export_db.py --profile DEFAULT --libs --set-export-dir ./migrate/library/`

```$ migrate-master % python export_db.py --profile DEFAULT --libs --set-export-dir ./migrate/library/
Starting complete library log at 2021-10-19 13:30:49.916253
Get: https://xxx.cloud.databricks.com/api/1.2/libraries/list
Get: https://xxx.cloud.databricks.com/api/1.2/libraries/status?libraryId=3300448733786976
Get: https://xxx.cloud.databricks.com/api/1.2/libraries/status?libraryId=3300448733786978
Get: https://xxx.cloud.databricks.com/api/1.2/libraries/status?libraryId=3300448733786979
Get: https://xxx.cloud.databricks.com/api/2.0/clusters/list
Get: https://xxx.cloud.databricks.com/api/2.0/libraries/cluster-status?cluster_id=0715-182634-maven980
Get: https://xxx.cloud.databricks.com/api/2.0/libraries/cluster-status?cluster_id=0712-215903-nice699
Get: https://xxx.cloud.databricks.com/api/2.0/libraries/cluster-status?cluster_id=0721-082536-door924
Get: https://xxx.cloud.databricks.com/api/2.0/libraries/cluster-status?cluster_id=1012-153846-yr42ahq
Get: https://xxx.cloud.databricks.com/api/2.0/libraries/cluster-status?cluster_id=1015-100320-1aa202pe
Get: https://xxx.cloud.databricks.com/api/2.0/libraries/cluster-status?cluster_id=1013-103250-ayhhrpqw
Get: https://xxx.cloud.databricks.com/api/2.0/libraries/cluster-status?cluster_id=1005-083644-sox292
Get: https://xxx.cloud.databricks.com/api/2.0/libraries/cluster-status?cluster_id=0924-132801-mill849
Complete Library Download Time: 0:00:21.297887```

