### PR TITLE
Renew token

### DIFF
--- a/dbclient/dbclient.py
+++ b/dbclient/dbclient.py
@@ -32,7 +32,7 @@ class dbclient:
     Rest API Wrapper for Databricks APIs
     """
     # set of http error codes to throw an exception if hit. Handles client and auth errors
-    http_error_codes = (401, 403)
+    http_error_codes = [401]
 
     def __init__(self, configs):
         self._profile = configs['profile']

--- a/dbclient/dbclient.py
+++ b/dbclient/dbclient.py
@@ -119,7 +119,7 @@ class dbclient:
             os.rmdir(local_dir)
 
     def _loop_until_token_renewed(self):
-        interval = 120
+        interval = 20
         timeout = 86400
 
         for x in range(0, int(timeout / interval)):

--- a/dbclient/dbclient.py
+++ b/dbclient/dbclient.py
@@ -2,6 +2,8 @@ import json
 import os
 import requests
 import fileinput
+from dbclient import parser
+import time
 import requests.packages.urllib3
 
 global pprint_j
@@ -14,6 +16,17 @@ def pprint_j(i):
     print(json.dumps(i, indent=4, sort_keys=True))
 
 
+def url_validation(url):
+    if '/?o=' in url:
+        # if the workspace_id exists, lets remove it from the URL
+        url = re.sub("\/\?o=.*", '', url)
+    elif 'net/' == url[-4:]:
+        url = url[:-1]
+    elif 'com/' == url[-4:]:
+        url = url[:-1]
+    return url.rstrip("/")
+
+
 class dbclient:
     """
     Rest API Wrapper for Databricks APIs
@@ -22,11 +35,11 @@ class dbclient:
     http_error_codes = (401, 403)
 
     def __init__(self, configs):
-        self._token = {
-            'Authorization': 'Bearer {0}'.format(configs['token']), 
-            'User-Agent': 'databrickslabs-migrate/0.1.0'
-        }
-        self._url = configs['url'].rstrip("/")
+        self._profile = configs['profile']
+        self._url = ''
+        self._token = ''
+        self._raw_token = ''
+        self._update_url_and_token(configs['url'], configs['token'])
         self._export_dir = configs['export_dir']
         self._is_aws = configs['is_aws']
         self._skip_failed = configs['skip_failed']
@@ -39,6 +52,14 @@ class dbclient:
             os.environ['REQUESTS_CA_BUNDLE'] = ""
             os.environ['CURL_CA_BUNDLE'] = ""
         os.makedirs(self._export_dir, exist_ok=True)
+
+    def _update_url_and_token(self, url, token):
+        self._url = url_validation(url)
+        self._raw_token = token
+        self._token = {
+            'Authorization': 'Bearer {0}'.format(token),
+            'User-Agent': 'databrickslabs-migrate/0.1.0'
+        }
 
     def is_aws(self):
         return self._is_aws
@@ -96,68 +117,99 @@ class dbclient:
         if len(os.listdir(local_dir)) == 0:
             os.rmdir(local_dir)
 
+    def _loop_until_token_renewed(self):
+        while True:
+            print("Migration paused due to expired token. Trying to renew...")
+            login_args = parser.get_login_credentials(profile=self._profile)
+            url = login_args['host']
+            token = login_args['token']
+            if token == self._raw_token:
+                print("No new token found. Please renew token by running:\n" +
+                      f"$ databricks configure --token --profile {self._profile}\n" +
+                      "Will try again in 120 seconds.")
+                time.sleep(120)
+                continue
+
+            print("New token found. Migration resumed.")
+            self._update_url_and_token(url, token)
+            break
+
+    def _should_retry_with_new_token(self, raw_results):
+        if raw_results.status_code == 403 and "Error 403 Invalid access token." in raw_results.text:
+            self._loop_until_token_renewed()
+            return True
+        else:
+            return False
+
     def get(self, endpoint, json_params=None, version='2.0', print_json=False):
         if version:
             ver = version
-        full_endpoint = self._url + '/api/{0}'.format(ver) + endpoint
-        if self.is_verbose():
-            print("Get: {0}".format(full_endpoint))
-        if json_params:
-            raw_results = requests.get(full_endpoint, headers=self._token, params=json_params, verify=self._verify_ssl)
+
+        while True:
+            full_endpoint = self._url + '/api/{0}'.format(ver) + endpoint
+            if self.is_verbose():
+                print("Get: {0}".format(full_endpoint))
+            if json_params:
+                raw_results = requests.get(full_endpoint, headers=self._token, params=json_params, verify=self._verify_ssl)
+            else:
+                raw_results = requests.get(full_endpoint, headers=self._token, verify=self._verify_ssl)
+
+            if self._should_retry_with_new_token(raw_results):
+                continue
+
             http_status_code = raw_results.status_code
             if http_status_code in dbclient.http_error_codes:
                 raise Exception("Error: GET request failed with code {}\n{}".format(http_status_code, raw_results.text))
             results = raw_results.json()
-        else:
-            raw_results = requests.get(full_endpoint, headers=self._token, verify=self._verify_ssl)
-            http_status_code = raw_results.status_code
-            if http_status_code in dbclient.http_error_codes:
-                raise Exception("Error: GET request failed with code {}\n{}".format(http_status_code, raw_results.text))
-            results = raw_results.json()
-        if print_json:
-            print(json.dumps(results, indent=4, sort_keys=True))
-        if type(results) == list:
-            results = {'elements': results}
-        results['http_status_code'] = raw_results.status_code
-        return results
+            if print_json:
+                print(json.dumps(results, indent=4, sort_keys=True))
+            if type(results) == list:
+                results = {'elements': results}
+            results['http_status_code'] = http_status_code
+            return results
 
     def http_req(self, http_type, endpoint, json_params, version='2.0', print_json=False, files_json=None):
         if version:
             ver = version
-        full_endpoint = self._url + '/api/{0}'.format(ver) + endpoint
-        if self.is_verbose():
-            print("{0}: {1}".format(http_type, full_endpoint))
-        if json_params:
-            if http_type == 'post':
-                if files_json:
-                    raw_results = requests.post(full_endpoint, headers=self._token,
-                                                data=json_params, files=files_json, verify=self._verify_ssl)
-                else:
-                    raw_results = requests.post(full_endpoint, headers=self._token,
-                                                json=json_params, verify=self._verify_ssl)
-            if http_type == 'put':
-                raw_results = requests.put(full_endpoint, headers=self._token,
-                                           json=json_params, verify=self._verify_ssl)
-            if http_type == 'patch':
-                raw_results = requests.patch(full_endpoint, headers=self._token,
-                                             json=json_params, verify=self._verify_ssl)
+        while True:
+            full_endpoint = self._url + '/api/{0}'.format(ver) + endpoint
+            if self.is_verbose():
+                print("{0}: {1}".format(http_type, full_endpoint))
+            if json_params:
+                if http_type == 'post':
+                    if files_json:
+                        raw_results = requests.post(full_endpoint, headers=self._token,
+                                                    data=json_params, files=files_json, verify=self._verify_ssl)
+                    else:
+                        raw_results = requests.post(full_endpoint, headers=self._token,
+                                                    json=json_params, verify=self._verify_ssl)
+                if http_type == 'put':
+                    raw_results = requests.put(full_endpoint, headers=self._token,
+                                               json=json_params, verify=self._verify_ssl)
+                if http_type == 'patch':
+                    raw_results = requests.patch(full_endpoint, headers=self._token,
+                                                 json=json_params, verify=self._verify_ssl)
+            else:
+                print("Must have a payload in json_args param.")
+                return {}
+
+            if self._should_retry_with_new_token(raw_results):
+                continue
+
             http_status_code = raw_results.status_code
             if http_status_code in dbclient.http_error_codes:
                 raise Exception("Error: {0} request failed with code {1}\n{2}".format(http_type,
                                                                                       http_status_code,
                                                                                       raw_results.text))
             results = raw_results.json()
-        else:
-            print("Must have a payload in json_args param.")
-            return {}
-        if print_json:
-            print(json.dumps(results, indent=4, sort_keys=True))
-        # if results are empty, let's return the return status
-        if results:
-            results['http_status_code'] = raw_results.status_code
-            return results
-        else:
-            return {'http_status_code': raw_results.status_code}
+            if print_json:
+                print(json.dumps(results, indent=4, sort_keys=True))
+            # if results are empty, let's return the return status
+            if results:
+                results['http_status_code'] = raw_results.status_code
+                return results
+            else:
+                return {'http_status_code': raw_results.status_code}
 
     def post(self, endpoint, json_params, version='2.0', print_json=False, files_json=None):
         return self.http_req('post', endpoint, json_params, version, print_json, files_json)

--- a/dbclient/dbclient.py
+++ b/dbclient/dbclient.py
@@ -37,10 +37,10 @@ class dbclient:
 
     def __init__(self, configs):
         self._profile = configs['profile']
-        self._url = ''
         self._token = ''
         self._raw_token = ''
-        self._update_url_and_token(configs['url'], configs['token'])
+        self._url = url_validation(configs['url'])
+        self._update_token(configs['token'])
         self._export_dir = configs['export_dir']
         self._is_aws = configs['is_aws']
         self._skip_failed = configs['skip_failed']
@@ -54,8 +54,7 @@ class dbclient:
             os.environ['CURL_CA_BUNDLE'] = ""
         os.makedirs(self._export_dir, exist_ok=True)
 
-    def _update_url_and_token(self, url, token):
-        self._url = url_validation(url)
+    def _update_token(self, token):
         self._raw_token = token
         self._token = {
             'Authorization': 'Bearer {0}'.format(token),
@@ -123,9 +122,8 @@ class dbclient:
         timeout = 86400
 
         for x in range(0, int(timeout / interval)):
-            print(f"#{x} Migration paused due to expired token. Trying to renew...")
+            print(f"#{x} Migration paused due to invalid or expired token. Trying to renew...")
             login_args = parser.get_login_credentials(profile=self._profile)
-            url = login_args['host']
             token = login_args['token']
             if token == self._raw_token:
                 print("No new token found. Please renew token by running:\n" +
@@ -135,7 +133,7 @@ class dbclient:
                 continue
 
             print("New token found. Migration resumed.")
-            self._update_url_and_token(url, token)
+            self._update_token(token)
             return
 
         raise Exception(f"Failed to renew token after {timeout}s. Please rerun the pipeline.")

--- a/dbclient/dbclient.py
+++ b/dbclient/dbclient.py
@@ -2,6 +2,7 @@ import json
 import os
 import requests
 import fileinput
+import re
 from dbclient import parser
 import time
 import requests.packages.urllib3

--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -333,22 +333,11 @@ def prompt_for_input(message):
         sys.stdout.write("Please respond with 'yes' or 'no'")
 
 
-def url_validation(url):
-    if '/?o=' in url:
-        # if the workspace_id exists, lets remove it from the URL
-        new_url = re.sub("\/\?o=.*", '', url)
-        return new_url
-    elif 'net/' == url[-4:]:
-        return url[:-1]
-    elif 'com/' == url[-4:]:
-        return url[:-1]
-    return url
-
-
-def build_client_config(url, token, args):
+def build_client_config(profile, url, token, args):
     # cant use netrc credentials because requests module tries to load the credentials into http basic auth headers
     # aws is the default
-    config = {'url': url_validation(url),
+    config = {'profile': profile,
+              'url': url,
               'token': token,
               'is_aws': (not args.azure),
               'verbose': (not args.silent),

--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -1,6 +1,5 @@
 import argparse
 import configparser
-import re
 from enum import Enum
 from os import path
 

--- a/dbclient/test/dbclient_test.py
+++ b/dbclient/test/dbclient_test.py
@@ -1,0 +1,59 @@
+import unittest
+import unittest.mock as mock
+from dbclient import dbclient
+
+def test_client_config():
+    return {
+        'profile': 'test_profile',
+        'url': 'https://test.url',
+        'token': 'test_token',
+        'is_aws': True,
+        'verbose': False,
+        'verify_ssl': False,
+        'skip_failed': True,
+        'debug': False,
+        'file_format': 'DBC',
+        'overwrite_notebooks': False,
+        'export_dir': 'test_dir'
+    }
+
+class DBClientTest(unittest.TestCase):
+    @mock.patch('time.sleep')
+    @mock.patch('dbclient.parser.get_login_credentials')
+    @mock.patch('requests.get')
+    def test_renew_token(self, mock_get, mock_get_login_credentials, mock_sleep):
+        config = test_client_config()
+        client = dbclient(config)
+
+        # Failure response due to expired token.
+        expired_response = mock.MagicMock()
+        expired_response.status_code = 403
+        expired_response.text = "<title>Error 403 Invalid access token.</title>"
+
+        # Successful response.
+        successful_response = mock.MagicMock()
+        successful_response.status_code = 200
+        successful_response.text = "CONTENT"
+        successful_response.json.return_value = {'user': 'foo'}
+
+        mock_get.side_effect = [expired_response, successful_response]
+
+        # Get the the old token first.
+        old_token = {
+            'host': 'http://test.url',
+            'token': 'test_token'
+        }
+
+        # Get the the new token eventually.
+        new_token = {
+            'host': 'http://new.url',
+            'token': 'new_token'
+        }
+        mock_get_login_credentials.side_effect = [old_token, old_token, new_token]
+
+        result = client.get("/endpoint")
+        assert(result == {'user': 'foo', 'http_status_code': 200})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/export_db.py
+++ b/export_db.py
@@ -24,7 +24,7 @@ def main():
     # parse the credentials
     url = login_args['host']
     token = login_args['token']
-    client_config = build_client_config(url, token, args)
+    client_config = build_client_config(args.profile, url, token, args)
 
     os.makedirs(client_config['export_dir'], exist_ok=True)
 

--- a/import_db.py
+++ b/import_db.py
@@ -19,7 +19,7 @@ def main():
     # cant use netrc credentials because requests module tries to load the credentials into http basic auth headers
     url = login_args['host']
     token = login_args['token']
-    client_config = build_client_config(url, token, args)
+    client_config = build_client_config(args.profile, url, token, args)
 
     makedirs(client_config['export_dir'], exist_ok=True)
 

--- a/migration_pipeline.py
+++ b/migration_pipeline.py
@@ -23,7 +23,7 @@ def build_pipeline() -> Pipeline:
     # basic auth headers parse the credentials
     url = login_args['host']
     token = login_args['token']
-    client_config = parser.build_client_config(url, token, args)
+    client_config = parser.build_client_config(args.profile, url, token, args)
 
     # Resume session if specified, and create a new one otherwise. Different session will work in
     # different export_dir in order to be isolated.

--- a/tasks/tasks_test.py
+++ b/tasks/tasks_test.py
@@ -8,6 +8,7 @@ test_export_dir = tempfile.TemporaryDirectory()
 
 def test_client_config():
     return {
+        'profile': 'test_profile',
         'url': 'https://test.url',
         'token': 'test_token',
         'is_aws': True,

--- a/test_connection.py
+++ b/test_connection.py
@@ -8,15 +8,15 @@ def main():
     parser = get_export_parser()
     # parse the args
     args = parser.parse_args()
-    p = args.profile
+    profile = args.profile
 
     # parse the path location of the Databricks CLI configuration
-    login_args = get_login_credentials(profile=p)
+    login_args = get_login_credentials(profile=profile)
 
     # parse the credentials
     url = login_args['host']
     token = login_args['token']
-    client_config = build_client_config(url, token, args)
+    client_config = build_client_config(profile, url, token, args)
 
     print("Test connection at {0} with profile {1}\n".format(url, args.profile))
     db_client = dbclient(client_config)


### PR DESCRIPTION
### What changes are proposed in this pull request?
Pause migration when expired token is detected. Wait until the token is renewed by runner and resume the migration pipeline.

### How is this tested?
Unittests
```
$ python3 -m unittest dbclient/test/dbclient_test.py
$ python3 -m unittest pipeline/pipeline_test.py
$ python3 -m unittest tasks/tasks_test.py
```

Locally tested by running:
```
$ python3 migration_pipeline.py --profile src
2021-11-15,23:03:07;INFO;Start `export_users_and_groups`
Migration paused due to expired token. Trying to renew...
No new token found. Please renew token by running:
$ databricks configure --token --profile src
Will try again in 120 seconds.
Migration paused due to expired token. Trying to renew...
New token found. Migration resumed.
2021-11-15,23:05:17;INFO;Complete Users Export Time: 0:02:10.097683
```