### PR TITLE
Make it work for dbadmin user in all cases

### DIFF
--- a/dbclient/TableACLsClient.py
+++ b/dbclient/TableACLsClient.py
@@ -231,8 +231,10 @@ class TableACLsClient(ClustersClient):
 
         user_name = self.get_current_username(must_be_admin=True)
         if self.DB_ADMIN_SUFFIX in user_name:
-            user_name = "admin"
-        export_table_acls_workspace_path = f"/Users/{user_name}/tmp/migrate/Export_Table_ACLs.py"
+            notebook_parent_path = ""
+        else:
+            notebook_parent_path = f"/Users/{user_name}"
+        export_table_acls_workspace_path = f"{notebook_parent_path}/tmp/migrate/Export_Table_ACLs.py"
 
         self.import_file_to_workspace(self.EXPORT_TABLE_ACLS_LOCAL_PATH, export_table_acls_workspace_path)
 
@@ -273,8 +275,10 @@ class TableACLsClient(ClustersClient):
 
         user_name = self.get_current_username(must_be_admin=True)
         if self.DB_ADMIN_SUFFIX in user_name:
-            user_name = "admin"
-        import_table_acls_workspace_path = f"/Users/{user_name}/tmp/migrate/Import_Table_ACLs.py"
+            notebook_parent_path = ""
+        else:
+            notebook_parent_path = f"/Users/{user_name}"
+        import_table_acls_workspace_path = f"{notebook_parent_path}/tmp/migrate/Import_Table_ACLs.py"
         self.import_file_to_workspace(self.IMPORT_TABLE_ACLS_LOCAL_PATH, import_table_acls_workspace_path)
 
         dbfs_acls_input_path = "dbfs:/tmp/migrate/table_acl_perms.json.gz"

--- a/migration_pipeline.py
+++ b/migration_pipeline.py
@@ -26,6 +26,9 @@ def build_pipeline(args) -> Pipeline:
     # Resume session if specified, and create a new one otherwise. Different session will work in
     # different export_dir in order to be isolated.
     session = args.session if args.session else generate_session()
+
+    print(f"Using the session id: {session}")
+
     client_config['session'] = session
     client_config['export_dir'] = os.path.join(client_config['export_dir'], session) + '/'
 


### PR DESCRIPTION
It turned out that not all workspaces (for legacy or w.e. reasons) necessarily have the "admin" folders. So if the invoker is dbadmin user, we create the tmp directory on the top level directory