### PR TITLE
Make --cluster-name optional

### DIFF
--- a/data/aws_cluster.json
+++ b/data/aws_cluster.json
@@ -1,11 +1,10 @@
 {
   "num_workers": 1,
-  "cluster_name": "API_Metastore_Work_Leave_Me_Alone",
+  "cluster_name": "Workspace_Migration_Work_Leave_Me_Alone",
   "spark_version": "6.5.x-scala2.11",
   "aws_attributes": {
       "first_on_demand": 1,
       "availability": "SPOT_WITH_FALLBACK",
-      "zone_id": "us-west-2b",
       "spot_bid_price_percent": 100,
       "ebs_volume_count": 0
   },

--- a/dbclient/ClustersClient.py
+++ b/dbclient/ClustersClient.py
@@ -276,7 +276,9 @@ class ClustersClient(dbclient):
                 acl_args = {'access_control_list' : self.build_acl_args(data['access_control_list'])}
                 cid = self.get_cluster_id_by_name(cluster_name)
                 if cid is None:
-                    raise ValueError('Cluster id must exist in new env. Re-import cluster configs.')
+                    error_message = f'Cluster id must exist in new env for cluster_name: {cluster_name}. ' \
+                                    f'Re-import cluster configs.'
+                    raise ValueError(error_message)
                 api = f'/preview/permissions/clusters/{cid}'
                 resp = self.put(api, acl_args)
                 print(resp)

--- a/dbclient/SecretsClient.py
+++ b/dbclient/SecretsClient.py
@@ -31,12 +31,12 @@ class SecretsClient(ClustersClient):
         s_value = results_get.get('data')
         return s_value
 
-    def log_all_secrets(self, cluster_name, log_dir='secret_scopes/'):
+    def log_all_secrets(self, cluster_name=None, log_dir='secret_scopes/'):
         scopes_dir = self.get_export_dir() + log_dir
         scopes_list = self.get_secret_scopes_list()
         os.makedirs(scopes_dir, exist_ok=True)
         start = timer()
-        cid = self.start_cluster_by_name(cluster_name)
+        cid = self.start_cluster_by_name(cluster_name) if cluster_name else self.launch_cluster()
         time.sleep(5)
         ec_id = self.get_execution_context(cid)
         for scope_json in scopes_list:

--- a/dbclient/TableACLsClient.py
+++ b/dbclient/TableACLsClient.py
@@ -231,8 +231,10 @@ class TableACLsClient(ClustersClient):
 
         user_name = self.get_current_username(must_be_admin=True)
         if self.DB_ADMIN_SUFFIX in user_name:
-            user_name = "admin"
-        export_table_acls_workspace_path = f"/Users/{user_name}/tmp/migrate/Export_Table_ACLs.py"
+            notebook_parent_path = ""
+        else:
+            notebook_parent_path = f"/Users/{user_name}"
+        export_table_acls_workspace_path = f"{notebook_parent_path}/tmp/migrate/Export_Table_ACLs.py"
 
         self.import_file_to_workspace(self.EXPORT_TABLE_ACLS_LOCAL_PATH, export_table_acls_workspace_path)
 
@@ -273,8 +275,10 @@ class TableACLsClient(ClustersClient):
 
         user_name = self.get_current_username(must_be_admin=True)
         if self.DB_ADMIN_SUFFIX in user_name:
-            user_name = "admin"
-        import_table_acls_workspace_path = f"/Users/{user_name}/tmp/migrate/Import_Table_ACLs.py"
+            notebook_parent_path = ""
+        else:
+            notebook_parent_path = f"/Users/{user_name}"
+        import_table_acls_workspace_path = f"{notebook_parent_path}/tmp/migrate/Import_Table_ACLs.py"
         self.import_file_to_workspace(self.IMPORT_TABLE_ACLS_LOCAL_PATH, import_table_acls_workspace_path)
 
         dbfs_acls_input_path = "dbfs:/tmp/migrate/table_acl_perms.json.gz"

--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -391,7 +391,7 @@ def get_pipeline_parser() -> argparse.ArgumentParser:
     parser.add_argument('--set-export-dir', action='store',
                         help='Set the base directory to export artifacts')
 
-    parser.add_argument('--cluster-name', action='store', required=True,
+    parser.add_argument('--cluster-name', action='store', required=False,
                         help='Cluster name to export the metastore to a specific cluster. Cluster will be started.')
 
     # Workspace arguments

--- a/migration_pipeline.py
+++ b/migration_pipeline.py
@@ -26,6 +26,9 @@ def build_pipeline(args) -> Pipeline:
     # Resume session if specified, and create a new one otherwise. Different session will work in
     # different export_dir in order to be isolated.
     session = args.session if args.session else generate_session()
+
+    print(f"Using the session id: {session}")
+
     client_config['session'] = session
     client_config['export_dir'] = os.path.join(client_config['export_dir'], session) + '/'
 


### PR DESCRIPTION
This PR makes the --cluster-name flag optional by making the downstream tasks launch cluster by itself.
Launch cluster is noop if the the cluster is already up and running.

Manual testing:
```
# Export (without --cluster-name):
python3 migration_pipeline.py --profile prod_src_miklos --export-pipeline --use-checkpoint


# Import (without --cluster-name):
python3 migration_pipeline.py --profile prod_dst_kevin --import-pipeline --use-checkpoint --session 20211207125516
```