### PR TITLE
Data integrity validation implementation #2

### DIFF
--- a/data/aws_cluster.json
+++ b/data/aws_cluster.json
@@ -1,11 +1,10 @@
 {
   "num_workers": 1,
-  "cluster_name": "API_Metastore_Work_Leave_Me_Alone",
+  "cluster_name": "Workspace_Migration_Work_Leave_Me_Alone",
   "spark_version": "6.5.x-scala2.11",
   "aws_attributes": {
       "first_on_demand": 1,
       "availability": "SPOT_WITH_FALLBACK",
-      "zone_id": "us-west-2b",
       "spot_bid_price_percent": 100,
       "ebs_volume_count": 0
   },

--- a/dbclient/ClustersClient.py
+++ b/dbclient/ClustersClient.py
@@ -276,7 +276,9 @@ class ClustersClient(dbclient):
                 acl_args = {'access_control_list' : self.build_acl_args(data['access_control_list'])}
                 cid = self.get_cluster_id_by_name(cluster_name)
                 if cid is None:
-                    raise ValueError('Cluster id must exist in new env. Re-import cluster configs.')
+                    error_message = f'Cluster id must exist in new env for cluster_name: {cluster_name}. ' \
+                                    f'Re-import cluster configs.'
+                    raise ValueError(error_message)
                 api = f'/preview/permissions/clusters/{cid}'
                 resp = self.put(api, acl_args)
                 print(resp)

--- a/dbclient/SecretsClient.py
+++ b/dbclient/SecretsClient.py
@@ -31,12 +31,12 @@ class SecretsClient(ClustersClient):
         s_value = results_get.get('data')
         return s_value
 
-    def log_all_secrets(self, cluster_name, log_dir='secret_scopes/'):
+    def log_all_secrets(self, cluster_name=None, log_dir='secret_scopes/'):
         scopes_dir = self.get_export_dir() + log_dir
         scopes_list = self.get_secret_scopes_list()
         os.makedirs(scopes_dir, exist_ok=True)
         start = timer()
-        cid = self.start_cluster_by_name(cluster_name)
+        cid = self.start_cluster_by_name(cluster_name) if cluster_name else self.launch_cluster()
         time.sleep(5)
         ec_id = self.get_execution_context(cid)
         for scope_json in scopes_list:

--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -409,7 +409,7 @@ def get_pipeline_parser() -> argparse.ArgumentParser:
     parser.add_argument('--set-export-dir', action='store',
                         help='Set the base directory to export artifacts')
 
-    parser.add_argument('--cluster-name', action='store', required=True,
+    parser.add_argument('--cluster-name', action='store', required=False,
                         help='Cluster name to export the metastore to a specific cluster. Cluster will be started.')
 
     # Workspace arguments

--- a/migration_pipeline.py
+++ b/migration_pipeline.py
@@ -187,6 +187,7 @@ def build_validate_pipeline(client_config, checkpoint_service, args):
             ),
         }))
     # WorkspaceItemLogExportTask
+    # TODO(yubing): compare artifacts.
     workspace_item_config = DiffConfig(primary_key='path', ignored_keys={'object_id'})
     add_diff_task("validate-user_dirs", "user_dirs.log", workspace_item_config)
     add_diff_task("validate-user_workspace", "user_workspace.log", workspace_item_config)

--- a/migration_pipeline.py
+++ b/migration_pipeline.py
@@ -9,10 +9,8 @@ from checkpoint_service import CheckpointService
 def generate_session(args) -> str:
     if args.validate_pipeline:
         prefix = 'V'
-    elif args.export_pipeline:
-        prefix = 'E'
     else:
-        prefix = 'I'
+        prefix = 'M'
 
     return prefix + datetime.now().strftime('%Y%m%d%H%M%S')
 

--- a/migration_pipeline.py
+++ b/migration_pipeline.py
@@ -76,10 +76,8 @@ def build_export_pipeline(client_config, checkpoint_service, args) -> Pipeline:
     pipeline = Pipeline(client_config['export_dir'], completed_pipeline_steps, args.dry_run)
     export_instance_profiles = pipeline.add_task(InstanceProfileExportTask(client_config, wmconstants.INSTANCE_PROFILES in skip_tasks))
     export_users = pipeline.add_task(UserExportTask(client_config, wmconstants.USERS in skip_tasks), [export_instance_profiles])
-    # TODO: list dirs
     export_groups = pipeline.add_task(GroupExportTask(client_config, wmconstants.GROUPS in skip_tasks), [export_users])
     workspace_item_log_export = pipeline.add_task(WorkspaceItemLogExportTask(client_config, checkpoint_service, wmconstants.WORKSPACE_ITEM_LOG in skip_tasks), [export_groups])
-    # TODO
     export_workspace_acls = pipeline.add_task(WorkspaceACLExportTask(client_config, checkpoint_service, wmconstants.WORKSPACE_ACLS in skip_tasks), [workspace_item_log_export])
     export_notebooks = pipeline.add_task(NotebookExportTask(client_config, checkpoint_service, wmconstants.NOTEBOOKS in skip_tasks), [workspace_item_log_export])
     export_secrets = pipeline.add_task(SecretExportTask(client_config, args, wmconstants.SECRETS in skip_tasks), [export_groups])

--- a/migration_pipeline.py
+++ b/migration_pipeline.py
@@ -130,6 +130,7 @@ def build_validate_pipeline(client_config, checkpoint_service, args):
     source_dir = os.path.join(base_dir, args.validate_source_session) + '/'
     destination_dir = os.path.join(base_dir, args.validate_destination_session) + '/'
 
+    init_diff_logger(client_config['export_dir'])
     pipeline = Pipeline(client_config['export_dir'], completed_pipeline_steps, args.dry_run)
 
     def add_diff_task(name, config, file_path, parents=None):

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -390,10 +390,12 @@ class DiffTask(AbstractTask):
         self.config = config
 
     def run(self):
-        print(f"----------------------------  {self.name} Start -----------------------------------")
-        source_data = validate.prepare_diff_input(read_json_file(self.source), self.config)
-        destination_data = validate.prepare_diff_input(read_json_file(self.destination),
-                                                       self.config)
-        diff = diff_json(source_data, destination_data)
+        diff_logger().info(f"------------------------  {self.name} Start -------------------------")
+        raw_source = read_json_file(self.source)
+        prepared_source = validate.prepare_diff_input(raw_source, self.config)
+        raw_destination = read_json_file(self.destination)
+        prepared_destination = validate.prepare_diff_input(raw_destination, self.config)
+        diff_logger().info(f"Object counts {len(raw_source)} <-> {len(raw_destination)}")
+        diff = diff_json(prepared_source, prepared_destination)
         print_diff(diff)
-        print(f"---------------------------- {self.name} Complete --------------------------------")
+        diff_logger().info(f"------------------------  {self.name} Complete ----------------------")

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -1,6 +1,7 @@
 import logging
 
 import json
+import os
 
 import validate
 from pipeline import AbstractTask
@@ -382,6 +383,23 @@ def read_json_file(file):
     return [json.loads(line) for line in lines]
 
 
+def diff_files(source, destination, config):
+    diff_logger().info(f"---------------- Compare {source} <-> {destination} ---------------------")
+    raw_source = read_json_file(source)
+    diff_logger().info(f"### Parsing {source} ###")
+    prepared_source = validate.prepare_diff_input(raw_source, config)
+
+    raw_destination = read_json_file(destination)
+    diff_logger().info(f"### Parsing {destination} ###")
+    prepared_destination = validate.prepare_diff_input(raw_destination, config)
+
+    diff_logger().info(f"Object counts {len(raw_source)} <-> {len(raw_destination)}")
+
+    diff_logger().info(f"### Comparing {source} and {destination} ###")
+    diff = diff_json(prepared_source, prepared_destination)
+    print_diff(diff)
+
+
 class DiffTask(AbstractTask):
     def __init__(self, name, source, destination, config=None):
         super().__init__(name)
@@ -390,20 +408,31 @@ class DiffTask(AbstractTask):
         self.config = config
 
     def run(self):
-        diff_logger().info(f"########################  {self.name} Start #########################")
+        diff_logger().info(f"######################### {self.name} Start #########################")
+        diff_files(self.source, self.destination, self.config)
+        diff_logger().info(f"######################### {self.name} Complete ######################")
 
-        raw_source = read_json_file(self.source)
-        diff_logger().info(f"### Parsing {self.source} ###")
-        prepared_source = validate.prepare_diff_input(raw_source, self.config)
 
-        raw_destination = read_json_file(self.destination)
-        diff_logger().info(f"### Parsing {self.destination} ###")
-        prepared_destination = validate.prepare_diff_input(raw_destination, self.config)
+class DirDiffTask(AbstractTask):
+    def __init__(self, name, source, destination, config):
+        super().__init__(name)
+        self.source = source
+        self.destination = destination
+        self.config = config
 
-        diff_logger().info(f"Object counts {len(raw_source)} <-> {len(raw_destination)}")
+    def run(self):
+        diff_logger().info(f"######################## {self.name} Start ##########################")
+        source_files = set(os.listdir(self.source))
+        destination_files = set(os.listdir(self.destination))
 
-        diff_logger().info(f"### Comparing {self.source} and {self.destination} ###")
-        diff = diff_json(prepared_source, prepared_destination)
-        print_diff(diff)
+        for file in source_files.union(destination_files):
+            source_file = os.path.join(self.source, file)
+            destination_file = os.path.join(self.destination, file)
+            if file not in source_files:
+                diff_logger().info(f"MISS_FILE_SOURCE:\n> {source_file}")
+            elif file not in destination_files:
+                diff_logger().info(f"MISS_FILE_DESTINATION:\n< {destination_file}")
+            else:
+                diff_files(source_file, destination_file, self.config)
 
-        diff_logger().info(f"########################  {self.name} Complete ######################")
+        diff_logger().info(f"######################### {self.name} Complete ######################")

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -4,6 +4,7 @@ import json
 import os
 
 import validate
+from collections import defaultdict
 from pipeline import AbstractTask
 from dbclient import *
 from validate import *
@@ -393,10 +394,12 @@ def diff_files(source, destination, config):
     logging.info(f"### Parsing {destination} ###")
     prepared_destination = validate.prepare_diff_input(raw_destination, config)
 
-    logging.info(f"Object counts {len(raw_source)} <-> {len(raw_destination)}")
-
     logging.info(f"### Comparing {source} and {destination} ###")
-    diff = diff_json(prepared_source, prepared_destination)
+    logging.info(f"Object counts {len(raw_source)} <-> {len(raw_destination)}")
+    counters = defaultdict(int)
+    diff = diff_json(prepared_source, prepared_destination, counters)
+    if counters:
+        logging.info(f"Diff counts {str(dict(counters))}")
     print_diff(diff)
 
 

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -411,9 +411,8 @@ class DiffTask(AbstractTask):
         self.config = config
 
     def run(self):
-        logging.info(f"######################### {self.name} Start #########################")
+        logging.info(f"############################# {self.name} #################################")
         diff_files(self.source, self.destination, self.config)
-        logging.info(f"######################### {self.name} Complete ######################")
 
 
 class DirDiffTask(AbstractTask):
@@ -424,7 +423,7 @@ class DirDiffTask(AbstractTask):
         self.config = config
 
     def run(self):
-        logging.info(f"######################## {self.name} Start ##########################")
+        logging.info(f"############################# {self.name} #################################")
         source_files = set(os.listdir(self.source))
         destination_files = set(os.listdir(self.destination))
 
@@ -437,5 +436,3 @@ class DirDiffTask(AbstractTask):
                 logging.info(f"MISS_FILE_DESTINATION:\n< {destination_file}")
             else:
                 diff_files(source_file, destination_file, self.config)
-
-        logging.info(f"######################### {self.name} Complete ######################")

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -390,12 +390,20 @@ class DiffTask(AbstractTask):
         self.config = config
 
     def run(self):
-        diff_logger().info(f"------------------------  {self.name} Start -------------------------")
+        diff_logger().info(f"########################  {self.name} Start #########################")
+
         raw_source = read_json_file(self.source)
+        diff_logger().info(f"### Parsing {self.source} ###")
         prepared_source = validate.prepare_diff_input(raw_source, self.config)
+
         raw_destination = read_json_file(self.destination)
+        diff_logger().info(f"### Parsing {self.destination} ###")
         prepared_destination = validate.prepare_diff_input(raw_destination, self.config)
+
         diff_logger().info(f"Object counts {len(raw_source)} <-> {len(raw_destination)}")
+
+        diff_logger().info(f"### Comparing {self.source} and {self.destination} ###")
         diff = diff_json(prepared_source, prepared_destination)
         print_diff(diff)
-        diff_logger().info(f"------------------------  {self.name} Complete ----------------------")
+
+        diff_logger().info(f"########################  {self.name} Complete ######################")

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -384,18 +384,18 @@ def read_json_file(file):
 
 
 def diff_files(source, destination, config):
-    diff_logger().info(f"---------------- Compare {source} <-> {destination} ---------------------")
+    logging.info(f"---------------- Compare {source} <-> {destination} ---------------------")
     raw_source = read_json_file(source)
-    diff_logger().info(f"### Parsing {source} ###")
+    logging.info(f"### Parsing {source} ###")
     prepared_source = validate.prepare_diff_input(raw_source, config)
 
     raw_destination = read_json_file(destination)
-    diff_logger().info(f"### Parsing {destination} ###")
+    logging.info(f"### Parsing {destination} ###")
     prepared_destination = validate.prepare_diff_input(raw_destination, config)
 
-    diff_logger().info(f"Object counts {len(raw_source)} <-> {len(raw_destination)}")
+    logging.info(f"Object counts {len(raw_source)} <-> {len(raw_destination)}")
 
-    diff_logger().info(f"### Comparing {source} and {destination} ###")
+    logging.info(f"### Comparing {source} and {destination} ###")
     diff = diff_json(prepared_source, prepared_destination)
     print_diff(diff)
 
@@ -408,9 +408,9 @@ class DiffTask(AbstractTask):
         self.config = config
 
     def run(self):
-        diff_logger().info(f"######################### {self.name} Start #########################")
+        logging.info(f"######################### {self.name} Start #########################")
         diff_files(self.source, self.destination, self.config)
-        diff_logger().info(f"######################### {self.name} Complete ######################")
+        logging.info(f"######################### {self.name} Complete ######################")
 
 
 class DirDiffTask(AbstractTask):
@@ -421,7 +421,7 @@ class DirDiffTask(AbstractTask):
         self.config = config
 
     def run(self):
-        diff_logger().info(f"######################## {self.name} Start ##########################")
+        logging.info(f"######################## {self.name} Start ##########################")
         source_files = set(os.listdir(self.source))
         destination_files = set(os.listdir(self.destination))
 
@@ -429,10 +429,10 @@ class DirDiffTask(AbstractTask):
             source_file = os.path.join(self.source, file)
             destination_file = os.path.join(self.destination, file)
             if file not in source_files:
-                diff_logger().info(f"MISS_FILE_SOURCE:\n> {source_file}")
+                logging.info(f"MISS_FILE_SOURCE:\n> {source_file}")
             elif file not in destination_files:
-                diff_logger().info(f"MISS_FILE_DESTINATION:\n< {destination_file}")
+                logging.info(f"MISS_FILE_DESTINATION:\n< {destination_file}")
             else:
                 diff_files(source_file, destination_file, self.config)
 
-        diff_logger().info(f"######################### {self.name} Complete ######################")
+        logging.info(f"######################### {self.name} Complete ######################")

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -390,8 +390,10 @@ class DiffTask(AbstractTask):
         self.config = config
 
     def run(self):
+        print(f"----------------------------  {self.name} Start -----------------------------------")
         source_data = validate.prepare_diff_input(read_json_file(self.source), self.config)
         destination_data = validate.prepare_diff_input(read_json_file(self.destination),
                                                        self.config)
         diff = diff_json(source_data, destination_data)
         print_diff(diff)
+        print(f"---------------------------- {self.name} Complete --------------------------------")

--- a/validate/__init__.py
+++ b/validate/__init__.py
@@ -1,3 +1,4 @@
 from .json_diff import *
 
-__all__ = ['print_diff', 'prepare_diff_input', 'DiffConfig', 'diff_json']
+__all__ = ['print_diff', 'prepare_diff_input', 'DiffConfig', 'diff_json', 'diff_logger',
+           'init_diff_logger']

--- a/validate/__init__.py
+++ b/validate/__init__.py
@@ -1,4 +1,3 @@
 from .json_diff import *
 
-__all__ = ['print_diff', 'prepare_diff_input', 'DiffConfig', 'diff_json', 'diff_logger',
-           'init_diff_logger']
+__all__ = ['print_diff', 'prepare_diff_input', 'DiffConfig', 'diff_json', 'init_diff_logger']

--- a/validate/json_diff.py
+++ b/validate/json_diff.py
@@ -144,19 +144,13 @@ class DiffConfig:
         self.children = children
 
 
-_diff_logger = logging.getLogger('diff-logger')
+_diff_logger = logging.getLogger('validate')
 
 
 def init_diff_logger(base_dir):
     _diff_logger.setLevel(logging.INFO)
-
-    ch = logging.StreamHandler()
-    ch.setLevel(logging.INFO)
-
     fh = logging.FileHandler(os.path.join(base_dir, "validation.log"))
     fh.setLevel(logging.INFO)
-
-    _diff_logger.addHandler(ch)
     _diff_logger.addHandler(fh)
 
 

--- a/validate/json_diff_test.py
+++ b/validate/json_diff_test.py
@@ -1,6 +1,8 @@
 import unittest
 from .json_diff import *
 
+init_diff_logger("/tmp")
+
 
 class JsonDiffTest(unittest.TestCase):
     def test_equal(self):
@@ -166,6 +168,31 @@ class PrepareDiffInputTest(unittest.TestCase):
                         )
                 }))
         )
+
+    def test_duplicates(self):
+        self.assertEqual(
+            {
+                'foo': {
+                    'b': {'key': 'b', 'value': 'y'},
+                    'a': {'key': 'a', 'value': 'q'},
+                    'c': {'key': 'c', 'value': 'n'}
+                },
+                'bar': 'baz'
+            },
+            prepare_diff_input(
+                {
+                    'foo': [{'key': 'b', 'value': 'y'},
+                            {'key': 'c', 'value': 'n'},
+                            {'key': 'c', 'value': 'm'},
+                            {'key': 'a', 'value': 'q'}],
+                    'bar': 'baz'
+                },
+                DiffConfig(children={
+                    'foo':
+                        DiffConfig(
+                            primary_key='key'
+                        )
+                })))
 
 
 class PrintDiffTest(unittest.TestCase):

--- a/validate/json_diff_test.py
+++ b/validate/json_diff_test.py
@@ -22,6 +22,7 @@ class JsonDiffTest(unittest.TestCase):
         self.assertEqual(ValueDiff(1.0, 2.0, expected_counters), diff_json(1.0, 2.0, counters))
         self.assertEqual(ValueDiff('hello', 'world', expected_counters), diff_json('hello', 'world', counters))
         self.assertEqual(counters, expected_counters)
+        self.assertEqual(dict(counters), {'VALUE_MISMATCH': 3})
 
     def test_type_diff(self):
         counters = defaultdict(int)
@@ -31,6 +32,7 @@ class JsonDiffTest(unittest.TestCase):
         self.assertEqual(TypeDiff(2.0, {}, expected_counters), diff_json(2.0, {}, counters))
         self.assertEqual(TypeDiff({}, 1, expected_counters), diff_json({}, 1, counters))
         self.assertEqual(counters, expected_counters)
+        self.assertEqual(dict(counters), {'TYPE_MISMATCH': 4})
 
     def test_dict_diff(self):
         counters = defaultdict(int)
@@ -45,6 +47,8 @@ class JsonDiffTest(unittest.TestCase):
                                              {'f': 3, 's': 'world', 'i': 2, 'r': 'destination'},
                                              counters))
         self.assertEqual(counters, expected_counters)
+        self.assertEqual(dict(counters), {
+            'TYPE_MISMATCH': 1, 'VALUE_MISMATCH': 2, 'MISS_DESTINATION': 1, 'MISS_SOURCE': 1})
 
     def test_set_diff(self):
         counters = defaultdict(int)
@@ -55,6 +59,7 @@ class JsonDiffTest(unittest.TestCase):
         self.assertEqual(expected, diff_json({'source', 'common'},
                                              {'destination', 'common'}, counters))
         self.assertEqual(counters, expected_counters)
+        self.assertEqual(dict(counters), {'MISS_DESTINATION': 1, 'MISS_SOURCE': 1})
 
     def test_nested_dict_diff(self):
         counters = defaultdict(int)
@@ -72,6 +77,8 @@ class JsonDiffTest(unittest.TestCase):
             {'i': 1, 'f': 2.0, 'e': 'equal', 'n': {'s': 'hello', 'l': 'source'}},
             {'f': 3, 'i': 2, 'e': 'equal', 'n': {'s': 'world', 'r': 'destination'}}, counters))
         self.assertEqual(counters, expected_counters)
+        self.assertEqual(dict(counters), {
+            'TYPE_MISMATCH': 1, 'VALUE_MISMATCH': 2, 'MISS_DESTINATION': 1, 'MISS_SOURCE': 1})
 
 
 class PrepareDiffInputTest(unittest.TestCase):

--- a/validate/json_diff_test.py
+++ b/validate/json_diff_test.py
@@ -28,17 +28,17 @@ class JsonDiffTest(unittest.TestCase):
         expected.add_child('i', ValueDiff(1, 2))
         expected.add_child('f', TypeDiff(2.0, 3))
         expected.add_child('s', ValueDiff('hello', 'world'))
-        expected.add_child('l', Miss('RIGHT', 'left'))
-        expected.add_child('r', Miss('LEFT', 'right'))
-        self.assertEqual(expected, diff_json({'i': 1, 'f': 2.0, 's': 'hello', 'l': 'left'},
-                                             {'f': 3, 's': 'world', 'i': 2, 'r': 'right'}))
+        expected.add_child('l', Miss('DESTINATION', 'source'))
+        expected.add_child('r', Miss('SOURCE', 'destination'))
+        self.assertEqual(expected, diff_json({'i': 1, 'f': 2.0, 's': 'hello', 'l': 'source'},
+                                             {'f': 3, 's': 'world', 'i': 2, 'r': 'destination'}))
 
     def test_set_diff(self):
         expected = DictDiff()
-        expected.add_child('left', Miss('RIGHT', 'left'))
-        expected.add_child('right', Miss('LEFT', 'right'))
-        self.assertEqual(expected, diff_json({'left', 'common'},
-                                             {'right', 'common'}))
+        expected.add_child('source', Miss('DESTINATION', 'source'))
+        expected.add_child('destination', Miss('SOURCE', 'destination'))
+        self.assertEqual(expected, diff_json({'source', 'common'},
+                                             {'destination', 'common'}))
 
     def test_nested_dict_diff(self):
         expected1 = DictDiff()
@@ -47,12 +47,12 @@ class JsonDiffTest(unittest.TestCase):
 
         expected2 = DictDiff()
         expected2.add_child('s', ValueDiff('hello', 'world'))
-        expected2.add_child('l', Miss('RIGHT', 'left'))
-        expected2.add_child('r', Miss('LEFT', 'right'))
+        expected2.add_child('l', Miss('DESTINATION', 'source'))
+        expected2.add_child('r', Miss('SOURCE', 'destination'))
         expected1.add_child('n', expected2)
         self.assertEqual(expected1, diff_json(
-            {'i': 1, 'f': 2.0, 'e': 'equal', 'n': {'s': 'hello', 'l': 'left'}},
-            {'f': 3, 'i': 2, 'e': 'equal', 'n': {'s': 'world', 'r': 'right'}}))
+            {'i': 1, 'f': 2.0, 'e': 'equal', 'n': {'s': 'hello', 'l': 'source'}},
+            {'f': 3, 'i': 2, 'e': 'equal', 'n': {'s': 'world', 'r': 'destination'}}))
 
 
 class PrepareDiffInputTest(unittest.TestCase):
@@ -202,8 +202,8 @@ class PrintDiffTest(unittest.TestCase):
         expected1.add_child('f', TypeDiff(2.0, 3))
         expected2 = DictDiff()
         expected2.add_child('s', ValueDiff('hello', 'world'))
-        expected2.add_child('l', Miss('RIGHT', 'left'))
-        expected2.add_child('r', Miss('LEFT', 'right'))
+        expected2.add_child('l', Miss('DESTINATION', 'source'))
+        expected2.add_child('r', Miss('SOURCE', 'destination'))
         expected1.add_child('n', expected2)
         print_diff(expected1, prefix="SIMPLE")
         # TODO(Yubing): Check output.

--- a/validate/json_diff_test.py
+++ b/validate/json_diff_test.py
@@ -135,6 +135,70 @@ class PrepareDiffInputTest(unittest.TestCase):
                 }))
         )
 
+    def test_hash_key(self):
+        self.maxDiff = None
+        self.assertEqual(
+            {
+                'foo': {
+                    "{'key': 'b', 'value': 'y', 'info': {100: {'id': 100, 'v': '111'}}}":
+                        {'key': 'b', 'value': 'y', 'info': {100: {'id': 100, 'v': '111'}}},
+                    "{'key': 'a', 'value': 'q', 'info': {200: {'id': 200, 'v': '222'}}}":
+                        {'key': 'a', 'value': 'q', 'info': {200: {'id': 200, 'v': '222'}}},
+                    "{'key': 'c', 'value': 'n', 'info': {300: {'id': 300, 'v': '333'}}}":
+                        {'key': 'c', 'value': 'n', 'info': {300: {'id': 300, 'v': '333'}}}
+                },
+                'bar': 'baz'
+            },
+            prepare_diff_input(
+                {
+                    'foo': [
+                        {'key': 'b', 'value': 'y', 'info': [{'id': 100, 'v': '111'}]},
+                        {'key': 'c', 'value': 'n', 'info': [{'id': 300, 'v': '333'}]},
+                        {'key': 'a', 'value': 'q', 'info': [{'id': 200, 'v': '222'}]},
+                    ],
+                    'bar': 'baz',
+                },
+                DiffConfig(children={
+                    'foo':
+                        DiffConfig(
+                            primary_key='__HASH__',
+                            children={
+                                'info': DiffConfig(primary_key='id')
+                            }
+                        )
+                }))
+        )
+
+    def test_multiple_keys(self):
+        self.assertEqual(
+            {
+                'foo': {
+                    'b': {'key': 'b', 'value': 'y', 'info': {100: {'id': 100, 'v': '111'}}},
+                    'a': {'key': 'a', 'value': 'q', 'info': {200: {'id': 200, 'v': '222'}}},
+                    'c': {'key2': 'c', 'value': 'n', 'info': {300: {'id': 300, 'v': '333'}}}
+                },
+                'bar': 'baz'
+            },
+            prepare_diff_input(
+                {
+                    'foo': [
+                        {'key': 'b', 'value': 'y', 'info': [{'id': 100, 'v': '111'}]},
+                        {'key2': 'c', 'value': 'n', 'info': [{'id': 300, 'v': '333'}]},
+                        {'key': 'a', 'value': 'q', 'info': [{'id': 200, 'v': '222'}]},
+                    ],
+                    'bar': 'baz',
+                },
+                DiffConfig(children={
+                    'foo':
+                        DiffConfig(
+                            primary_key=['key', 'key2'],
+                            children={
+                                'info': DiffConfig(primary_key='id')
+                            }
+                        )
+                }))
+        )
+
     def test_ignore(self):
         self.assertEqual(
             {


### PR DESCRIPTION
This PR includes:
- [x] Add object and diff counters.
- [x] Onboard more object types.
- [x] Warn duplicates.
- [x] Make outputs easier to read.

Tested
```python3 -m unittest validate/json_diff_test.py```
``` python3 migration_pipeline.py --validate-pipeline --validate-source-session=E20211209153920 --validate-destination-session=E20211209154049
Start validate-instance_profile
######################### validate-instance_profile Start #########################
---------------- Compare logs/E20211209153920/instance_profiles.log <-> logs/E20211209154049/instance_profiles.log ---------------------
### Parsing logs/E20211209153920/instance_profiles.log ###
### Parsing logs/E20211209154049/instance_profiles.log ###
### Comparing logs/E20211209153920/instance_profiles.log and logs/E20211209154049/instance_profiles.log ###
Object counts 1 <-> 1
No diff found.
######################### validate-instance_profile Complete ######################
validate-instance_profile Completed. Total time taken: 0:00:00.001716
Start validate-users
######################### validate-users Start #########################
---------------- Compare logs/E20211209153920/users.log <-> logs/E20211209154049/users.log ---------------------
### Parsing logs/E20211209153920/users.log ###
### Parsing logs/E20211209154049/users.log ###
### Comparing logs/E20211209153920/users.log and logs/E20211209154049/users.log ###
Object counts 26 <-> 27
Diff counts {'MISS_SOURCE': 4}
|mwc+user1@databricks.com|entitlements:MISS_SOURCE:
> {'allow-cluster-create': {'value': 'allow-cluster-create'}}

|mwc@databricks.com|entitlements:MISS_SOURCE:
> {'allow-cluster-create': {'value': 'allow-cluster-create'}}

|mwc@databricks.com|groups|aaaa:MISS_SOURCE:
> {'display': 'aaaa', 'type': 'direct'}

|tomi.schumacher+jobsnoadmin@databricks.com:MISS_SOURCE:
> {'emails': {'tomi.schumacher+jobsnoadmin@databricks.com': {'type': 'work', 'value': 'tomi.schumacher+jobsnoadmin@databricks.com', 'primary': True}}, 'displayName': 'Tomi jobsnoAdmin', 'name': {'familyName': 'jobsnoAdmin', 'givenName': 'Tomi'}, 'active': True, 'groups': {}, 'userName': 'tomi.schumacher+jobsnoadmin@databricks.com'}

######################### validate-users Complete ######################
validate-users Completed. Total time taken: 0:00:00.002714
Start validate-groups
######################## validate-groups Start ##########################
MISS_FILE_SOURCE:
> logs/E20211209153920/groups/aaaa
---------------- Compare logs/E20211209153920/groups/field <-> logs/E20211209154049/groups/field ---------------------
### Parsing logs/E20211209153920/groups/field ###
### Parsing logs/E20211209154049/groups/field ###
### Comparing logs/E20211209153920/groups/field and logs/E20211209154049/groups/field ###
Object counts 1 <-> 1
No diff found.
MISS_FILE_SOURCE:
> logs/E20211209153920/groups/testgroup
---------------- Compare logs/E20211209153920/groups/users <-> logs/E20211209154049/groups/users ---------------------
### Parsing logs/E20211209153920/groups/users ###
### Parsing logs/E20211209154049/groups/users ###
### Comparing logs/E20211209153920/groups/users and logs/E20211209154049/groups/users ###
Object counts 1 <-> 1
Diff counts {'MISS_SOURCE': 1}
|users|members|Tomi jobsnoAdmin:MISS_SOURCE:
> {'display': 'Tomi jobsnoAdmin', 'userName': 'tomi.schumacher+jobsnoadmin@databricks.com', 'type': 'user'}

---------------- Compare logs/E20211209153920/groups/admins <-> logs/E20211209154049/groups/admins ---------------------
### Parsing logs/E20211209153920/groups/admins ###
### Parsing logs/E20211209154049/groups/admins ###
### Comparing logs/E20211209153920/groups/admins and logs/E20211209154049/groups/admins ###
Object counts 1 <-> 1
No diff found.
---------------- Compare logs/E20211209153920/groups/tomi-acl-test-group <-> logs/E20211209154049/groups/tomi-acl-test-group ---------------------
### Parsing logs/E20211209153920/groups/tomi-acl-test-group ###
### Parsing logs/E20211209154049/groups/tomi-acl-test-group ###
### Comparing logs/E20211209153920/groups/tomi-acl-test-group and logs/E20211209154049/groups/tomi-acl-test-group ###
Object counts 1 <-> 1
No diff found.
---------------- Compare logs/E20211209153920/groups/tzars <-> logs/E20211209154049/groups/tzars ---------------------
### Parsing logs/E20211209153920/groups/tzars ###
### Parsing logs/E20211209154049/groups/tzars ###
### Comparing logs/E20211209153920/groups/tzars and logs/E20211209154049/groups/tzars ###
Object counts 1 <-> 1
No diff found.
---------------- Compare logs/E20211209153920/groups/analysts <-> logs/E20211209154049/groups/analysts ---------------------
```