### PR TITLE
Add missing re import in HiveClient

### DIFF
--- a/dbclient/HiveClient.py
+++ b/dbclient/HiveClient.py
@@ -1,12 +1,15 @@
 import ast
-import os
 import base64
-import wmconstants
+import logging
+import os
+import re
 import time
 from datetime import timedelta
 from timeit import default_timer as timer
-import logging
+
 import logging_utils
+import wmconstants
+
 from dbclient import *
 
 


### PR DESCRIPTION
This PR is to fix missing import for `re` library.