### PR TITLE
[PLAT-46716] Add ml python dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,11 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
           'cron-descriptor',
+          'mlflow-skinny',
+          'sqlparse',
           'requests'
       ],
-    py_modules=["export_db","import_db","test_connection"],
+    py_modules=["export_db","import_db","test_connection","migration_pipeline"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",


### PR DESCRIPTION
Added mlflow-skinny and sqlparse to setup.py

`python3 setup.py --install`

Example commands for creating and listing experiments worked after installing:
```
from mlflow.entities import ViewType
from mlflow.tracking import MlflowClient
import mlflow

mlflow.set_registry_uri("databricks://test_shard")
client = MlflowClient()

for name in ["Experiment 1", "Experiment 2"]:
    exp_id = client.create_experiment(name)

print(client.list_experiments(view_type=ViewType.ACTIVE_ONLY))

[<Experiment: artifact_location='file:///Users/kevinkim/migrate/mlruns/0', experiment_id='0', lifecycle_stage='active', name='Default', tags={}>, <Experiment: artifact_location='file:///Users/kevinkim/migrate/mlruns/1', ex
periment_id='1', lifecycle_stage='active', name='Experiment 1', tags={}>, <Experiment: artifact_location='file:///Users/kevinkim/migrate/mlruns/2', experiment_id='2', lifecycle_stage='active', name='Experiment 2', tags={}>
]
```