### PR TITLE
[PLAT-46718] Export ml experiment

### DIFF
--- a/dbclient/MLFlowClient.py
+++ b/dbclient/MLFlowClient.py
@@ -26,8 +26,6 @@ class MLFlowClient:
         experiments_logfile = mlflow_experiments_dir + log_file
         with open(experiments_logfile, 'w') as fp:
             for experiment in experiments:
-                # TODO(kevin): do try catch on get_experiment call
-                experiment_metadata = self.client.get_experiment(experiment.experiment_id)
-                fp.write(json.dumps(dict(experiment_metadata)) + '\n')
+               fp.write(json.dumps(dict(experiment)) + '\n')
         end = timer()
         logging.info("Complete MLflow Experiments Export Time: " + str(timedelta(seconds=end - start)))

--- a/dbclient/MLFlowClient.py
+++ b/dbclient/MLFlowClient.py
@@ -22,6 +22,10 @@ class MLFlowClient:
         )
         os.makedirs(mlflow_experiments_dir, exist_ok=True)
         start = timer()
+        # We do not do any pagination since ST workspaces do not have that many experiments count.
+        # Max is ~6k experiments for the moment.
+        # Consider using pagination(https://www.mlflow.org/docs/latest/python_api/mlflow.tracking.html) if
+        # a workspace has explosive number of experiments. (e.g. 200K)
         experiments = self.client.list_experiments(view_type=ViewType.ALL)
         experiments_logfile = mlflow_experiments_dir + log_file
         with open(experiments_logfile, 'w') as fp:

--- a/dbclient/MLFlowClient.py
+++ b/dbclient/MLFlowClient.py
@@ -1,0 +1,33 @@
+import os
+import json
+from datetime import timedelta
+from timeit import default_timer as timer
+import logging
+import logging_utils
+import mlflow
+from mlflow.tracking import MlflowClient
+from mlflow.entities import ViewType
+import wmconstants
+
+class MLFlowClient:
+    def __init__(self, configs, checkpoint_service):
+        self._checkpoint_service = checkpoint_service
+        self.export_dir = configs['export_dir']
+        self.client = MlflowClient(f"databricks://{configs['profile']}")
+
+    def export_mlflow_experiments(self, log_file='mlflow_experiments.log', log_dir=None):
+        mlflow_experiments_dir = log_dir if log_dir else self.export_dir
+        error_logger = logging_utils.get_error_logger(
+            wmconstants.WM_EXPORT, wmconstants.MLFLOW_EXPERIMENT_OBJECT, self.export_dir
+        )
+        os.makedirs(mlflow_experiments_dir, exist_ok=True)
+        start = timer()
+        experiments = self.client.list_experiments(view_type=ViewType.ALL)
+        experiments_logfile = mlflow_experiments_dir + log_file
+        with open(experiments_logfile, 'w') as fp:
+            for experiment in experiments:
+                # TODO(kevin): do try catch on get_experiment call
+                experiment_metadata = self.client.get_experiment(experiment.experiment_id)
+                fp.write(json.dumps(dict(experiment_metadata)) + '\n')
+        end = timer()
+        logging.info("Complete MLflow Experiments Export Time: " + str(timedelta(seconds=end - start)))

--- a/dbclient/__init__.py
+++ b/dbclient/__init__.py
@@ -9,4 +9,5 @@ from .WorkspaceClient import WorkspaceClient
 from .HiveClient import HiveClient
 from .SecretsClient import SecretsClient
 from .TableACLsClient import TableACLsClient
+from .MLFlowClient import MLFlowClient
 from .parser import *

--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -125,6 +125,10 @@ def get_export_parser():
     parser.add_argument('--secrets', action='store_true',
                         help='log all the secret scopes')
 
+    # get all mlflow experiments
+    parser.add_argument('--mlflow_experiments', action='store_true',
+                        help='log all the mlflow experiments')
+
     # get all metastore
     parser.add_argument('--metastore-unicode', action='store_true',
                         help='log all the metastore table definitions including unicode characters')

--- a/export_db.py
+++ b/export_db.py
@@ -282,6 +282,11 @@ def main():
         end = timer()
         print("Complete User Export Time: " + str(timedelta(seconds=end - start)))
 
+    if args.mlflow_experiments:
+        print("Exporting MLflow experiments.")
+        mlflow_c = MLFlowClient(client_config, checkpoint_service)
+        mlflow_c.export_mlflow_experiments()
+
     if args.reset_exports:
         print('Request to clean up old export directory')
         start = timer()

--- a/wmconstants.py
+++ b/wmconstants.py
@@ -13,6 +13,7 @@ CLUSTER_OBJECT = "clusters"
 INSTANCE_POOL_OBJECT = "instance_pools"
 JOB_OBJECT = "jobs"
 SECRET_OBJECT = "secrets"
+MLFLOW_EXPERIMENT_OBJECT = "mlflow_experiments"
 # Migration pipeline placeholder constants
 MIGRATION_PIPELINE_OBJECT_TYPE = "tasks"
 
@@ -34,6 +35,7 @@ INSTANCE_POOLS = "instance_pools"
 JOBS = "jobs"
 METASTORE = "metastore"
 METASTORE_TABLE_ACLS = "metastore_table_acls"
+MLFLOW_EXPERIMENTS = "mlflow_experiments"
 
 TASK_OBJECTS = [
     INSTANCE_PROFILES,
@@ -48,4 +50,5 @@ TASK_OBJECTS = [
     JOBS,
     METASTORE,
     METASTORE_TABLE_ACLS,
+    MLFLOW_EXPERIMENTS
 ]


### PR DESCRIPTION
usage:
`python3 export_db.py --profile $PROFILE --mlflow_experiments`

Tests:
```
python3 export_db.py --profile dogfood --mlflow_experiments
Exporting MLflow experiments.
2022-01-25,16:53:43;INFO;Complete MLflow Experiments Export Time: 0:00:06.048322

// writes logs/mlflow_experiments.log file (with 3954 items)
{"artifact_location": "dbfs:/databricks/mlflow/10065689", "experiment_id": "10065689", "lifecycle_stage": "active", "name": "/Users/aaron@databricks.com/Movie Recommendations", "tags": {"mlflow.ownerId": "", "mlflow.experimentType": "NOTEBOOK"}}
{"artifact_location": "dbfs:/databricks/mlflow/12174144", "experiment_id": "12174144", "lifecycle_stage": "active", "name": "/Users/aaron@databricks.com/Basic MLflow", "tags": {"mlflow.ownerId": "", "mlflow.experimentType": "NOTEBOOK"}}
{"artifact_location": "dbfs:/databricks/mlflow/12557050", "experiment_id": "12557050", "lifecycle_stage": "active", "name": "/Users/aaron@databricks.com/A", "tags": {"mlflow.ownerId": "", "mlflow.experimentType": "NOTEBOOK"}}
{"artifact_location": "dbfs:/databricks/mlflow/13430347", "experiment_id": "13430347", "lifecycle_stage": "active", "name": "/Shared/experiments/Default Experiment", "tags": {"mlflow.note.content": "test123 coool", "mlflow.ownerId": "101003", "mlflow.experimentType": "MLFLOW_EXPERIMENT", "mlflow.ownerEmail": "mlflow_migrator+dbadmin@databricks.com"}}
......
```

I will not add ML object exports to migration task yet, and leave the invokers to opt into migrate ml objects (since most of the customers do not migrate ml objects)