### PR TITLE
Add thread_safe_writer class

### DIFF
--- a/dbclient/WorkspaceClient.py
+++ b/dbclient/WorkspaceClient.py
@@ -1,6 +1,7 @@
 import base64
 from dbclient import *
 import wmconstants
+from thread_safe_writer import ThreadSafeWriter
 from timeit import default_timer as timer
 from datetime import timedelta
 import logging_utils
@@ -284,6 +285,10 @@ class WorkspaceClient(dbclient):
             err_msg = {'error': resp.get('error'), 'path': notebook_path}
             logging_utils.log_reponse_error(error_logger, resp, err_msg)
             return err_msg
+        if resp.get('error_code', None):
+            err_msg = {'error_code': resp.get('error_code'), 'path': notebook_path}
+            logging_utils.log_reponse_error(error_logger, resp, err_msg)
+            return err_msg
         nb_path = os.path.dirname(notebook_path)
         if nb_path != '/':
             # path is NOT empty, remove the trailing slash from export_dir
@@ -330,8 +335,22 @@ class WorkspaceClient(dbclient):
         if os.path.exists(libs_log):
             os.remove(libs_log)
 
-    def log_all_workspace_items(self, ws_path='/', workspace_log_file='user_workspace.log',
-                                libs_log_file='libraries.log', dir_log_file='user_dirs.log'):
+    def log_all_workspace_items_entry(self, ws_path='/', workspace_log_file='user_workspace.log', libs_log_file='libraries.log', dir_log_file='user_dirs.log'):
+        workspace_log_writer = ThreadSafeWriter(self.get_export_dir() + workspace_log_file, "a")
+        libs_log_writer = ThreadSafeWriter(self.get_export_dir() + libs_log_file, "a")
+        dir_log_writer = ThreadSafeWriter(self.get_export_dir() + dir_log_file, "a")
+
+        try:
+            num_nbs = self.log_all_workspace_items(ws_path=ws_path, workspace_log_writer=workspace_log_writer,
+                                        libs_log_writer=libs_log_writer, dir_log_writer=dir_log_writer)
+        finally:
+            workspace_log_writer.close()
+            libs_log_writer.close()
+            dir_log_writer.close()
+
+        return num_nbs
+
+    def log_all_workspace_items(self, ws_path, workspace_log_writer, libs_log_writer, dir_log_writer):
         """
         Loop and log all workspace items to download them at a later time
         :param ws_path: root path to log all the items of the notebook workspace
@@ -341,9 +360,6 @@ class WorkspaceClient(dbclient):
         :return:
         """
         # define log file names for notebooks, folders, and libraries
-        workspace_log = self.get_export_dir() + workspace_log_file
-        workspace_dir_log = self.get_export_dir() + dir_log_file
-        libs_log = self.get_export_dir() + libs_log_file
         if ws_path == '/':
             # default is the root path
             get_args = {'path': '/'}
@@ -362,25 +378,24 @@ class WorkspaceClient(dbclient):
             # should be no notebooks, but lets filter and can check later
             notebooks = self.filter_workspace_items(items, 'NOTEBOOK')
             libraries = self.filter_workspace_items(items, 'LIBRARY')
-            with open(workspace_log, "a") as ws_fp, open(libs_log, "a") as libs_fp:
-                for x in notebooks:
-                    # notebook objects has path and object_id
-                    if self.is_verbose():
-                        logging.info("Saving path: {0}".format(x.get('path')))
-                    ws_fp.write(json.dumps(x) + '\n')
-                    num_nbs += 1
-                for y in libraries:
-                    libs_fp.write(json.dumps(y) + '\n')
+            for x in notebooks:
+                # notebook objects has path and object_id
+                if self.is_verbose():
+                    logging.info("Saving path: {0}".format(x.get('path')))
+                workspace_log_writer.write(json.dumps(x) + '\n')
+                num_nbs += 1
+            for y in libraries:
+                libs_log_writer.write(json.dumps(y) + '\n')
             # log all directories to export permissions
-            if folders:
-                with open(workspace_dir_log, "a") as dir_fp:
-                    for f in folders:
-                        dir_path = f.get('path', None)
-                        if not WorkspaceClient.is_user_trash(dir_path):
-                            dir_fp.write(json.dumps(f) + '\n')
-                            num_nbs += self.log_all_workspace_items(ws_path=dir_path,
-                                                                    workspace_log_file=workspace_log_file,
-                                                                    libs_log_file=libs_log_file)
+
+                for f in folders:
+                    dir_path = f.get('path', None)
+                    if not WorkspaceClient.is_user_trash(dir_path):
+                        dir_log_writer.write(json.dumps(f) + '\n')
+                        num_nbs += self.log_all_workspace_items(ws_path=ws_path,
+                                                                workspace_log_writer=workspace_log_writer,
+                                                                libs_log_writer=libs_log_writer,
+                                                                dir_log_writer=dir_log_writer)
         return num_nbs
 
     def get_obj_id_by_path(self, input_path):

--- a/dbclient/WorkspaceClient.py
+++ b/dbclient/WorkspaceClient.py
@@ -387,12 +387,12 @@ class WorkspaceClient(dbclient):
             for y in libraries:
                 libs_log_writer.write(json.dumps(y) + '\n')
             # log all directories to export permissions
-
+            if folders:
                 for f in folders:
                     dir_path = f.get('path', None)
                     if not WorkspaceClient.is_user_trash(dir_path):
                         dir_log_writer.write(json.dumps(f) + '\n')
-                        num_nbs += self.log_all_workspace_items(ws_path=ws_path,
+                        num_nbs += self.log_all_workspace_items(ws_path=dir_path,
                                                                 workspace_log_writer=workspace_log_writer,
                                                                 libs_log_writer=libs_log_writer,
                                                                 dir_log_writer=dir_log_writer)

--- a/export_db.py
+++ b/export_db.py
@@ -5,6 +5,7 @@ import os
 import shutil
 from checkpoint_service import CheckpointService
 import logging_utils
+from thread_safe_writer import ThreadSafeWriter
 
 # python 3.6
 def main():
@@ -64,7 +65,7 @@ def main():
         start = timer()
         # log notebooks and libraries
         ws_c.init_workspace_logfiles()
-        num_notebooks = ws_c.log_all_workspace_items()
+        num_notebooks = ws_c.log_all_workspace_items_entry()
         print("Total number of notebooks logged: ", num_notebooks)
         end = timer()
         print("Complete Workspace Export Time: " + str(timedelta(seconds=end - start)))

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -101,7 +101,7 @@ class WorkspaceItemLogExportTask(AbstractTask):
         ws_c = WorkspaceClient(self.client_config, self.checkpoint_service)
         # log notebooks and libraries
         ws_c.init_workspace_logfiles()
-        num_notebooks = ws_c.log_all_workspace_items()
+        num_notebooks = ws_c.log_all_workspace_items_entry()
         print("Total number of notebooks logged: ", num_notebooks)
 
 

--- a/thread_safe_writer.py
+++ b/thread_safe_writer.py
@@ -1,7 +1,7 @@
 from queue import Queue, Empty
 from threading import Thread
 
-class ThreadSafeWriter:
+class ThreadSafeWriter():
     """Class that ensures the thread-safe file write via the Synchronized Queue object.
     For example, this class can be used by multiple threads to write to the same file safely.
     This class is not useful when parallelization is done across multiple files.
@@ -17,9 +17,11 @@ class ThreadSafeWriter:
         self.queue = Queue()
         self.finished = False
         # Single thread of actually writing to a file.
-        Thread(name = "ThreadSafeWriter", target=self.internal_writer).start()
+        Thread(name="ThreadSafeWriter", target=self.internal_writer).start()
+
     def write(self, data):
         self.queue.put(data)
+
     def internal_writer(self):
         while not self.finished:
             if not self.queue.empty():
@@ -27,21 +29,8 @@ class ThreadSafeWriter:
                 self.filewriter.write(data)
                 self.filewriter.flush()
                 self.queue.task_done()
+
     def close(self):
         self.queue.join()
         self.finished = True
         self.filewriter.close()
-
-# def fn(writer, data):
-#   time.sleep(5)
-#   writer.write(data + " ")
-#
-# with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
-#   futures = {executor.submit(fn, writer, str(data)): data for data in range(20)}
-#   for future in concurrent.futures.as_completed(futures):
-#     dl_resp = future.result()
-
-#use it like ordinary open like this:
-# w = SafeWriter("filename", "w")
-# w.write("can be used among multiple threads")
-# w.close() #it is really important to close or the program would not end

--- a/thread_safe_writer.py
+++ b/thread_safe_writer.py
@@ -1,0 +1,47 @@
+from queue import Queue, Empty
+from threading import Thread
+
+class ThreadSafeWriter:
+    """Class that ensures the thread-safe file write via the Synchronized Queue object.
+    For example, this class can be used by multiple threads to write to the same file safely.
+    This class is not useful when parallelization is done across multiple files.
+
+    Initialize by passing in the file open args.
+    e.g. writer = ThreadSafeWriter("file_to_write.txt", "w")
+         writer.write("content1")
+         writer.write("content2")
+         writer.close()
+    """
+    def __init__(self, *args):
+        self.filewriter = open(*args)
+        self.queue = Queue()
+        self.finished = False
+        # Single thread of actually writing to a file.
+        Thread(name = "ThreadSafeWriter", target=self.internal_writer).start()
+    def write(self, data):
+        self.queue.put(data)
+    def internal_writer(self):
+        while not self.finished:
+            if not self.queue.empty():
+                data = self.queue.get(block=True)
+                self.filewriter.write(data)
+                self.filewriter.flush()
+                self.queue.task_done()
+    def close(self):
+        self.queue.join()
+        self.finished = True
+        self.filewriter.close()
+
+# def fn(writer, data):
+#   time.sleep(5)
+#   writer.write(data + " ")
+#
+# with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
+#   futures = {executor.submit(fn, writer, str(data)): data for data in range(20)}
+#   for future in concurrent.futures.as_completed(futures):
+#     dl_resp = future.result()
+
+#use it like ordinary open like this:
+# w = SafeWriter("filename", "w")
+# w.write("can be used among multiple threads")
+# w.close() #it is really important to close or the program would not end


### PR DESCRIPTION
This PR adds ThreadSafeWriter class which ensures thread-safety when writing to a file. This is useful when this Writer object can be used by multiple thread to to execute and write results to a single file without having to worry about race conditions among multiple threads.

This class makes sense to be used when multiple thread writes to a single static file (vs multiple threads write to each different files in which case, we don't need to worry about race conditions from different threads)

In this PR, we make `python3 export_db.py --profile $profile --workspace` use this new class when writing data to 
user_dirs.log,  libraries.log, user_workspace.log files

Testing:

unit test:
```
python3 -m unittest test/thread_safe_writer_test.py
```

manual testing:
Compared the output files after running `python3 export_db.py --profile shardqa --workspace`

```
wc -l user_dirs.log
    2363 user_dirs.log
 wc -l user_dirs_1_thread.log
    2363 user_dirs_1_thread.log
diff <(sort user_dirs.log) <(sort user_dirs_1_thread.log)

wc -l libraries.log
     115 libraries.log
wc -l libraries_1_thread.log
     115 libraries_1_thread.log
diff <(sort libraries.log) <(sort libraries_1_thread.log)

wc -l user_workspace.log
   10233 user_workspace.log
wc -l user_workspace_1_thread.log
   10233 user_workspace_1_thread.log
diff <(sort user_workspace.log) <(sort user_workspace_1_thread.log)
```

