### PR TITLE
Support mlflow_experiment import

### DIFF
--- a/checkpoint_service.py
+++ b/checkpoint_service.py
@@ -1,6 +1,7 @@
 import os
 from abc import ABC, abstractmethod
 import logging
+from thread_safe_writer import ThreadSafeWriter
 
 class AbstractCheckpointKeySet(ABC):
     """Abstract base class for checkpoint read and write."""
@@ -23,7 +24,8 @@ class CheckpointKeySet(AbstractCheckpointKeySet):
         :param checkpoint_file: file to read / write object keys for checkpointing
         """
         self._checkpoint_file = checkpoint_file
-        self._checkpoint_file_append_fp = open(checkpoint_file, 'a+')
+        # By using ThreadSafeWriter, checkpointer is also thread-safe.
+        self._checkpoint_file_append_fp = ThreadSafeWriter(checkpoint_file, 'a')
         self._checkpoint_key_set = set()
         self._restore_from_checkpoint_file()
 

--- a/dbclient/MLFlowClient.py
+++ b/dbclient/MLFlowClient.py
@@ -92,7 +92,7 @@ class MLFlowClient:
         artifact_location when creating experiment objects.
         """
         if artifact_location == None or \
-                artifact_location.startswith("dbfs:/databricks/mlflow-tracking") or \
-                artifact_location.startswith("dbfs:/databricks/mlflow"):
+                artifact_location.startswith("dbfs:/databricks/mlflow-tracking/") or \
+                artifact_location.startswith("dbfs:/databricks/mlflow/"):
             return None
         return artifact_location

--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -126,7 +126,7 @@ def get_export_parser():
                         help='log all the secret scopes')
 
     # get all mlflow experiments
-    parser.add_argument('--mlflow_experiments', action='store_true',
+    parser.add_argument('--mlflow-experiments', action='store_true',
                         help='log all the mlflow experiments')
 
     # get all metastore
@@ -302,9 +302,13 @@ def get_import_parser():
     parser.add_argument('--skip-failed', action='store_true', default=False,
                         help='Skip missing users that do not exist when importing user notebooks')
 
-    # get all secret scopes
+    # import all secret scopes
     parser.add_argument('--secrets', action='store_true',
                         help='Import all secret scopes')
+
+    # import all mlflow experiments
+    parser.add_argument('--mlflow-experiments', action='store_true',
+                        help='log all the mlflow experiments')
 
     # get azure logs
     parser.add_argument('--azure', action='store_true',

--- a/import_db.py
+++ b/import_db.py
@@ -234,6 +234,8 @@ def main():
 
     if args.mlflow_experiments:
         print("Importing MLflow experiments.")
+        # TODO(kevin): Once https://github.com/databrickslabs/migrate/pull/103 is merged, pass in
+        #              args.num_parallel
         mlflow_c = MLFlowClient(client_config, checkpoint_service)
         mlflow_c.import_mlflow_experiments()
 

--- a/import_db.py
+++ b/import_db.py
@@ -232,6 +232,11 @@ def main():
         end = timer()
         # print("Complete Library Import Time: " + str(timedelta(seconds=end - start)))
 
+    if args.mlflow_experiments:
+        print("Importing MLflow experiments.")
+        mlflow_c = MLFlowClient(client_config, checkpoint_service)
+        mlflow_c.import_mlflow_experiments()
+
     if args.get_repair_log:
         print("Finding partitioned tables to repair at {0}".format(now))
         start = timer()

--- a/import_db.py
+++ b/import_db.py
@@ -234,10 +234,8 @@ def main():
 
     if args.mlflow_experiments:
         print("Importing MLflow experiments.")
-        # TODO(kevin): Once https://github.com/databrickslabs/migrate/pull/103 is merged, pass in
-        #              args.num_parallel
         mlflow_c = MLFlowClient(client_config, checkpoint_service)
-        mlflow_c.import_mlflow_experiments()
+        mlflow_c.import_mlflow_experiments(num_parallel=args.num_parallel)
 
     if args.get_repair_log:
         print("Finding partitioned tables to repair at {0}".format(now))

--- a/logging_utils.py
+++ b/logging_utils.py
@@ -43,6 +43,9 @@ def log_reponse_error(error_logger,
                       response,
                       error_msg=None,
                       ignore_error_list=default_ignore_error_list):
+    """
+    Logs errors based on the response. Usually used when the response is the http response.
+    """
     if check_error(response, ignore_error_list):
         if error_msg:
             error_logger.error(error_msg)


### PR DESCRIPTION
Supports mlflow_experiment import

```
python3 import_db.py --profile mwc_dst --mlflow-experiments --use-checkpoint
```

The command consumes `mlflow_experiments.log` (the output of export_db.py --mlflow-experiments) and creates the experiment objects in the destination workspace. Also it outputs `mlflow_experiments_id_map.log` which has a format of
```
{"old_id": "3825356326110958", "new_id": "2025369099255681"}
{"old_id": "3825356326110957", "new_id": "2025369099255680"}
```
which will be consumed by run import later.

This PR also makes the checkpointer use ThreadSafeWriter

Notes:
- mlflow_experiments_id_map.log only appends instead of rewriting. This is to ensure that upon failures and retries, it still keeps the already imported experiments.
- meaning, one should never remove the mlflow_experiments_id_map.log after running the import command in order to not lose the already imported experiment objects' id mapping.


