### PR TITLE
skip '/Shared' directories acl

### DIFF
--- a/dbclient/WorkspaceClient.py
+++ b/dbclient/WorkspaceClient.py
@@ -520,6 +520,12 @@ class WorkspaceClient(dbclient):
         # the object_type
         object_type = object_acl.get('object_type', None)
         obj_path = object_acl['path']
+
+        # We cannot modify '/Shared' directory's ACL
+        if obj_path == "/Shared" and object_type == "directory":
+            logging.info("We cannot modify /Shared directory's ACL. Skipping..")
+            return
+
         if self.is_user_ws_item(obj_path):
             ws_user = self.get_user(obj_path)
             if not self.does_user_exist(ws_user):


### PR DESCRIPTION
/Shared directory's ACL cannot be modified by design. We should skip /Shared directory when importing the ACL.
```
2022-03-01,15:49:43;WARNING;{"error_code": "INTERNAL_ERROR", "message": "Cannot modify permissions of directory 44857340052148"}

2022-03-01,15:49:43;ERROR;{"error_code": "INTERNAL_ERROR", "message": "Cannot modify permissions of directory 44857340052148", "http_status_code": 500}
```

