### PR TITLE
[PLAT-46720] Support mlflow run export

### DIFF
--- a/dbclient/MLFlowClient.py
+++ b/dbclient/MLFlowClient.py
@@ -11,12 +11,117 @@ import wmconstants
 from thread_safe_writer import ThreadSafeWriter
 import concurrent
 from concurrent.futures import ThreadPoolExecutor
+import sqlite3
 
 class MLFlowClient:
     def __init__(self, configs, checkpoint_service):
         self._checkpoint_service = checkpoint_service
         self.export_dir = configs['export_dir']
         self.client = MlflowClient(f"databricks://{configs['profile']}")
+
+    def export_mlflow_runs(self, log_sql_file='mlflow_runs.db', experiment_log='mlflow_experiments.log', num_parallel=4):
+        """
+        Exports the Mlflow run objects. This can be run only after export_mlflow_experiments is complete.
+        Unlike other objects, we save the data into sqlite tables, given the possible scale of runs objects.
+        """
+        print(f"num_parallel: {num_parallel}")
+        experiments_logfile = self.export_dir + experiment_log
+        mlflow_runs_checkpointer = self._checkpoint_service.get_checkpoint_key_set(
+            wmconstants.WM_EXPORT, wmconstants.MLFLOW_RUNS
+        )
+
+        start = timer()
+        con = sqlite3.connect(self.export_dir + log_sql_file)
+        with con:
+            con.execute('''
+              CREATE TABLE IF NOT EXISTS runs (id TEXT UNIQUE, start_time INT, run_obj TEXT)
+            ''')
+        con.close()
+
+        error_logger = logging_utils.get_error_logger(
+            wmconstants.WM_EXPORT, wmconstants.MLFLOW_RUN_OBJECT, self.export_dir
+        )
+        with open(experiments_logfile, 'r') as fp:
+            with ThreadPoolExecutor(max_workers=num_parallel) as executor:
+                futures = [executor.submit(self._export_runs_in_an_experiment, log_sql_file, experiment_str, mlflow_runs_checkpointer, error_logger) for experiment_str in fp]
+                results = concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
+                for result in results.done:
+                    if result.exception() is not None:
+                        raise result.exception()
+
+        end = timer()
+        logging.info("Complete MLflow Runs Export Time: " + str(timedelta(seconds=end - start)))
+
+
+    '''
+    # Later we may consume the exported runs as the following
+    def import_mlflow_runs(...):
+        con = sqlite3.connect(log_sql_file, check_same_thread=False)
+        cur = con.cursor()
+
+        # Later, we might enforce start_time > xxx
+        cur.execute("SELECT * FROM runs")
+        runs = cur.fetchmany(1000)
+        while(len(runs) > 0):
+            # parallelize here
+            for run in runs:
+                run_id = run[0]
+                start_time = run[1]
+
+                run_obj = json.loads(run[2])
+                info = run_object['info']
+                metrics = run_object['metrics']
+                params = run_object['params']
+                tags = run_object['tags']
+    '''
+
+
+    def _export_runs_in_an_experiment(self, log_sql_file, experiment_str, checkpointer, error_logger):
+        experiment_id = json.loads(experiment_str).get('experiment_id')
+        logging.info("Working on runs for experiment_id: " + experiment_id)
+        # We checkpoint by experiment_id
+        if checkpointer.contains(experiment_id):
+            return
+        page_continue = True
+        token = None
+        is_there_exception = False
+        # Unlike experiments which usually don't have too much number of data,
+        # we must do page_token handling for runs.
+        while page_continue:
+            try:
+                runs = self.client.search_runs(experiment_id, run_view_type=ViewType.ACTIVE_ONLY, max_results=3000, page_token=token)
+            except RestException as error:
+                logging.info(f"search runs failed for id: {experiment_id}. Logging it to error file...")
+                error_logger.error(error.json)
+                is_there_exception = True
+            else:
+                # With multi-threading, we need to give enough timeout for each thread's connection to be made
+                # Upon DatabaseLock timeout exception, one can simply rerun the command since the checkpoint saves the
+                # progress
+                con = sqlite3.connect(self.export_dir + log_sql_file, timeout=180)
+                with con:
+                    for run in runs:
+                        self._save_run_data_to_sql(con, run)
+                con.close()
+                token = runs.token
+                page_continue = token is not None
+
+        if not is_there_exception:
+            checkpointer.write(experiment_id)
+
+    @classmethod
+    def _save_run_data_to_sql(cls, con, run):
+        run_id = run.info.run_id
+        start_time = run.info.start_time
+        run_object = {
+            "info": dict(run.info),
+            "metrics": dict(run.data.metrics),
+            "params": dict(run.data.params),
+            "tags": dict(run.data.tags)
+        }
+        # qmark style to avoid sql injection
+        con.execute("INSERT OR REPLACE INTO runs VALUES (?, ?, ?)", (run_id, start_time, json.dumps(run_object)))
+
 
     def export_mlflow_experiments(self, log_file='mlflow_experiments.log', log_dir=None):
         mlflow_experiments_dir = log_dir if log_dir else self.export_dir
@@ -35,7 +140,7 @@ class MLFlowClient:
         logging.info("Complete MLflow Experiments Export Time: " + str(timedelta(seconds=end - start)))
 
     def import_mlflow_experiments(self, log_file='mlflow_experiments.log', id_map_file='mlflow_experiments_id_map.log',
-                                  log_dir=None, num_parallel=4):
+                                  log_dir=None, num_parallel=6):
         mlflow_experiments_dir = log_dir if log_dir else self.export_dir
         experiments_logfile = mlflow_experiments_dir + log_file
         experiments_id_map_file = mlflow_experiments_dir + id_map_file
@@ -53,7 +158,10 @@ class MLFlowClient:
             with open(experiments_logfile, 'r') as fp:
                 with ThreadPoolExecutor(max_workers=num_parallel) as executor:
                     futures = [executor.submit(self._create_experiment, experiment_str, id_map_thread_safe_writer, mlflow_experiments_checkpointer, error_logger) for experiment_str in fp]
-                    concurrent.futures.wait(futures)
+                    results = concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
+                    for result in results.done:
+                        if result.exception() is not None:
+                            raise result.exception()
         finally:
             id_map_thread_safe_writer.close()
 

--- a/dbclient/MLFlowClient.py
+++ b/dbclient/MLFlowClient.py
@@ -24,7 +24,6 @@ class MLFlowClient:
         Exports the Mlflow run objects. This can be run only after export_mlflow_experiments is complete.
         Unlike other objects, we save the data into sqlite tables, given the possible scale of runs objects.
         """
-        print(f"num_parallel: {num_parallel}")
         experiments_logfile = self.export_dir + experiment_log
         mlflow_runs_checkpointer = self._checkpoint_service.get_checkpoint_key_set(
             wmconstants.WM_EXPORT, wmconstants.MLFLOW_RUNS
@@ -140,7 +139,7 @@ class MLFlowClient:
         logging.info("Complete MLflow Experiments Export Time: " + str(timedelta(seconds=end - start)))
 
     def import_mlflow_experiments(self, log_file='mlflow_experiments.log', id_map_file='mlflow_experiments_id_map.log',
-                                  log_dir=None, num_parallel=6):
+                                  log_dir=None, num_parallel=4):
         mlflow_experiments_dir = log_dir if log_dir else self.export_dir
         experiments_logfile = mlflow_experiments_dir + log_file
         experiments_id_map_file = mlflow_experiments_dir + id_map_file

--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -129,6 +129,10 @@ def get_export_parser():
     parser.add_argument('--mlflow-experiments', action='store_true',
                         help='log all the mlflow experiments')
 
+    # get all mlflow experiments
+    parser.add_argument('--mlflow-runs', action='store_true',
+                        help='log all the mlflow runs')
+
     # get all metastore
     parser.add_argument('--metastore-unicode', action='store_true',
                         help='log all the metastore table definitions including unicode characters')

--- a/dbclient/test/MLFlowClientTest.py
+++ b/dbclient/test/MLFlowClientTest.py
@@ -1,0 +1,127 @@
+import unittest
+import os
+import sqlite3
+from dbclient import MLFlowClient
+import json
+import concurrent.futures
+from mlflow.entities import Metric, Param, RunTag, RunData, RunInfo, Run
+
+MLFLOW_TEST_FILE = "dbclient/test/mlflow_runs_test.db"
+
+class MLFlowClientTest(unittest.TestCase):
+
+    @classmethod
+    def tearDownClass(cls):
+        if os.path.exists(MLFLOW_TEST_FILE):
+            os.remove(MLFLOW_TEST_FILE)
+
+    def _generate_run(self, i, runs_dict):
+        """
+        Generate a run object and save to runs_dict keyed by run_id.
+        Most of data just depends on i, and some data are hard-coded for simplicityGenerate n number of runs. Most of
+        data just depends on n, and some data are hard-coded for simplicity.
+        """
+        key = f"key{i}"
+        value = f"value{i}"
+        start_time = 123456 * i
+        end_time = start_time + (1000 * i)
+        run_id = f"run_id_{i}"
+
+        metrics = [Metric(key, value, start_time, "stage")]
+        params = [Param(key, value)]
+        tags = [RunTag(key, value)]
+        run_info = RunInfo(run_id, "experiment_id", "user_id", "status", start_time, end_time, "lifecycle_stage")
+        run = Run(
+                    run_info=run_info,
+                    run_data=RunData(
+                    metrics=metrics,
+                    params=params,
+                    tags=tags))
+        runs_dict[run_id] = run
+        return run
+
+    def _insert_run_data(self, run):
+        con = sqlite3.connect(MLFLOW_TEST_FILE, timeout=30)
+        with con:
+            MLFlowClient._save_run_data_to_sql(con, run)
+
+
+    def test_save_run_data_to_sql(self):
+        # Input data
+        run = self._generate_run(1, {})
+
+        con = sqlite3.connect(MLFLOW_TEST_FILE, timeout=10)
+        with con:
+            con.execute('''
+              DROP TABLE IF EXISTS runs
+            ''')
+            con.execute('''
+              CREATE TABLE runs (id TEXT UNIQUE, start_time INT, run_obj TEXT)
+            ''')
+            self._insert_run_data(run)
+            cur = con.execute('''
+              SELECT * FROM runs
+            ''')
+        fetched_run = cur.fetchone()
+        con.close()
+
+        fetched_run_id = fetched_run[0]
+        fetched_start_time = fetched_run[1]
+        fetched_run_obj = json.loads(fetched_run[2])
+
+        fetched_run_info = fetched_run_obj['info']
+        fetched_run_metrics = fetched_run_obj['metrics']
+        fetched_run_params = fetched_run_obj['params']
+        fetched_run_tags = fetched_run_obj['tags']
+
+        assert(run.info.run_id == fetched_run_id)
+        assert(run.info.start_time == fetched_start_time)
+        assert(dict(run.info) == fetched_run_info)
+        assert(dict(run.data.metrics) == fetched_run_metrics)
+        assert(dict(run.data.params) == fetched_run_params)
+        assert(dict(run.data.tags) == fetched_run_tags)
+
+
+    def test_parallel_save_run_data_to_sql(self):
+        con = sqlite3.connect(MLFLOW_TEST_FILE, timeout=10)
+        with con:
+            con.execute('''
+              DROP TABLE IF EXISTS runs
+            ''')
+            con.execute('''
+              CREATE TABLE runs (id TEXT UNIQUE, start_time INT, run_obj TEXT)
+            ''')
+
+        runs_dict = {}
+        num_runs = 2000
+        runs = [self._generate_run(i, runs_dict) for i in range(1, 1 + num_runs)]
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
+            futures = [executor.submit(self._insert_run_data(run)) for run in runs]
+            concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
+
+        with con:
+            cur = con.execute('''
+              SELECT * FROM runs
+            ''')
+        fetched_runs = cur.fetchmany(num_runs)
+        con.close()
+        assert(len(fetched_runs) == num_runs)
+
+        for fetched_run in fetched_runs:
+            fetched_run_id = fetched_run[0]
+            fetched_start_time = fetched_run[1]
+            fetched_run_obj = json.loads(fetched_run[2])
+
+            fetched_run_info = fetched_run_obj['info']
+            fetched_run_metrics = fetched_run_obj['metrics']
+            fetched_run_params = fetched_run_obj['params']
+            fetched_run_tags = fetched_run_obj['tags']
+
+            id = fetched_run_id
+            assert(runs_dict[id].info.run_id == fetched_run_id)
+            assert(runs_dict[id].info.start_time == fetched_start_time)
+            assert(dict(runs_dict[id].info) == fetched_run_info)
+            assert(dict(runs_dict[id].data.metrics) == fetched_run_metrics)
+            assert(dict(runs_dict[id].data.params) == fetched_run_params)
+            assert(dict(runs_dict[id].data.tags) == fetched_run_tags)

--- a/export_db.py
+++ b/export_db.py
@@ -287,6 +287,11 @@ def main():
         mlflow_c = MLFlowClient(client_config, checkpoint_service)
         mlflow_c.export_mlflow_experiments()
 
+    if args.mlflow_runs:
+        print("Exporting MLflow runs.")
+        mlflow_c = MLFlowClient(client_config, checkpoint_service)
+        mlflow_c.export_mlflow_runs(num_parallel=args.num_parallel)
+
     if args.reset_exports:
         print('Request to clean up old export directory')
         start = timer()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setuptools.setup(
     install_requires=[
           'cron-descriptor',
           'mlflow-skinny',
-          'sqlparse'
+          'sqlparse',
+          'requests'
     ],
     py_modules=["export_db","import_db","test_connection","migration_pipeline"],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,8 @@ setuptools.setup(
     install_requires=[
           'cron-descriptor',
           'mlflow-skinny',
-          'sqlparse',
-          'requests'
-      ],
+          'sqlparse'
+    ],
     py_modules=["export_db","import_db","test_connection","migration_pipeline"],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/wmconstants.py
+++ b/wmconstants.py
@@ -14,6 +14,7 @@ INSTANCE_POOL_OBJECT = "instance_pools"
 JOB_OBJECT = "jobs"
 SECRET_OBJECT = "secrets"
 MLFLOW_EXPERIMENT_OBJECT = "mlflow_experiments"
+MLFLOW_RUN_OBJECT = "mlflow_runs"
 # Migration pipeline placeholder constants
 MIGRATION_PIPELINE_OBJECT_TYPE = "tasks"
 
@@ -36,6 +37,7 @@ JOBS = "jobs"
 METASTORE = "metastore"
 METASTORE_TABLE_ACLS = "metastore_table_acls"
 MLFLOW_EXPERIMENTS = "mlflow_experiments"
+MLFLOW_RUNS = "mlflow_runs"
 
 TASK_OBJECTS = [
     INSTANCE_PROFILES,
@@ -50,5 +52,6 @@ TASK_OBJECTS = [
     JOBS,
     METASTORE,
     METASTORE_TABLE_ACLS,
-    MLFLOW_EXPERIMENTS
+    MLFLOW_EXPERIMENTS,
+    MLFLOW_RUNS
 ]


### PR DESCRIPTION
This PR supports the following command:
```
python3 export_db.py --profile dogfood --mlflow-runs --use-checkpoint --num-parallel 8

022-03-08,17:07:00;INFO;Complete MLflow Runs Export Time: 0:07:13.251757
```

Given the scale of the runs (total runs and runs per experimentId. total 220k runs for shard-dogfood), we store the run object data into sqlite. 

Unit test: `python3 -m unittest dbclient/test/MLFlowClientTest.py`
Manual test: 
```
python3 export_db.py --profile dogfood --mlflow-runs --use-checkpoint --num-parallel 1  (take 20 minutes)
python3 export_db.py --profile dogfood --mlflow-runs --use-checkpoint --num-parallel 8 (take 7 minutes)
python3 export_db.py --profile dogfood --mlflow-runs --use-checkpoint --num-parallel 10 (take 5 minutes)
```

Check the total size of the data to make sure different number of threads result in same number of data:
```
con_1 = sqlite3.connect("logs/mlflow_runs.db_1_thread", timeout=10)
con_1 = sqlite3.connect("logs/mlflow_runs.db_1_thread", timeout=10)
con_1 = sqlite3.connect("logs/mlflow_runs.db_1_thread", timeout=10)
cur_1 = con_1.execute('''SELECT COUNT(*) FROM runs''')
cur_1.fetchone()
(217947,)

con_2 = sqlite3.connect("logs/mlflow_runs.db_10_thread", timeout=10)
con_2 = sqlite3.connect("logs/mlflow_runs.db_10_thread", timeout=10)
cur_2 = con_2.execute('''SELECT COUNT(*) FROM runs''')
cur_2.fetchone()
(217947,)

con_3 = sqlite3.connect("logs/mlflow_runs.db_8_thread", timeout=10)
cur_3 = con_3.execute('''SELECT COUNT(*) FROM runs''')
cur_3.fetchone()
(217947,)
```