### PR TITLE
[Issue 126] Add http retry logic

### DIFF
--- a/dbclient/HiveClient.py
+++ b/dbclient/HiveClient.py
@@ -14,7 +14,7 @@ from dbclient import *
 class HiveClient(ClustersClient):
 
     def __init__(self, configs, checkpoint_service):
-        super().__init__(configs)
+        super().__init__(configs, checkpoint_service)
         self._checkpoint_service = checkpoint_service
 
     @staticmethod

--- a/dbclient/MLFlowClient.py
+++ b/dbclient/MLFlowClient.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from timeit import default_timer as timer
 import logging
 import logging_utils
+from threading_utils import propagate_exceptions
 from mlflow.tracking import MlflowClient
 from mlflow.entities import ViewType
 from mlflow.exceptions import RestException
@@ -54,6 +55,7 @@ class MLFlowClient:
                 with ThreadPoolExecutor(max_workers=num_parallel) as executor:
                     futures = [executor.submit(self._create_experiment, experiment_str, id_map_thread_safe_writer, mlflow_experiments_checkpointer, error_logger) for experiment_str in fp]
                     concurrent.futures.wait(futures)
+                    propagate_exceptions(futures)
         finally:
             id_map_thread_safe_writer.close()
 

--- a/dbclient/WorkspaceClient.py
+++ b/dbclient/WorkspaceClient.py
@@ -4,6 +4,7 @@ import wmconstants
 import concurrent
 from concurrent.futures import ThreadPoolExecutor
 from thread_safe_writer import ThreadSafeWriter
+from threading_utils import propagate_exceptions
 from timeit import default_timer as timer
 from datetime import timedelta
 import logging_utils
@@ -473,10 +474,8 @@ class WorkspaceClient(dbclient):
         with open(read_log_path, 'r') as read_fp:
             with ThreadPoolExecutor(max_workers=num_parallel) as executor:
                 futures = [executor.submit(_acl_log_helper, json_data) for json_data in read_fp]
-                results = concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
-                for result in results.done:
-                    if result.exception() is not None:
-                        raise result.exception()
+                concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
+                propagate_exceptions(futures)
 
     def log_all_workspace_acls(self, workspace_log_file='user_workspace.log',
                                dir_log_file='user_dirs.log',
@@ -567,20 +566,16 @@ class WorkspaceClient(dbclient):
         with open(notebook_acl_logs) as nb_acls_fp:
             with ThreadPoolExecutor(max_workers=num_parallel) as executor:
                 futures = [executor.submit(self.apply_acl_on_object, nb_acl_str, acl_notebooks_error_logger) for nb_acl_str in nb_acls_fp]
-                results = concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
-                for result in results.done:
-                    if result.exception() is not None:
-                        raise result.exception()
+                concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
+                propagate_exceptions(futures)
 
         acl_dir_error_logger = logging_utils.get_error_logger(
             wmconstants.WM_IMPORT, wmconstants.WORKSPACE_DIRECTORY_ACL_OBJECT, self.get_export_dir())
         with open(dir_acl_logs) as dir_acls_fp:
             with ThreadPoolExecutor(max_workers=num_parallel) as executor:
                 futures = [executor.submit(self.apply_acl_on_object, dir_acl_str, acl_dir_error_logger) for dir_acl_str in dir_acls_fp]
-                results = concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
-                for result in results.done:
-                    if result.exception() is not None:
-                        raise result.exception()
+                concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
+                propagate_exceptions(futures)
         print("Completed import ACLs of Notebooks and Directories")
 
     def get_current_users(self):
@@ -735,14 +730,10 @@ class WorkspaceClient(dbclient):
 
             with ThreadPoolExecutor(max_workers=num_parallel) as executor:
                 futures = [executor.submit(_file_upload_helper, file) for file in files]
-                results = concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
-                for result in results.done:
-                    if result.exception() is not None:
-                        raise result.exception()
+                concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
+                propagate_exceptions(futures)
 
         with ThreadPoolExecutor(max_workers=num_parallel) as executor:
             futures = [executor.submit(_upload_all_files, walk[0], walk[1], walk[2]) for walk in self.walk(src_dir)]
-            results = concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
-            for result in results.done:
-                if result.exception() is not None:
-                    raise result.exception()
+            concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
+            propagate_exceptions(futures)

--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -222,6 +222,11 @@ def get_export_parser():
 
     parser.add_argument('--num-parallel', type=int, default=4, help='Number of parallel threads to use to '
                                                                           'export/import')
+
+    parser.add_argument('--retry-total', type=int, default=3, help='Total number or retries when making calls to Databricks API')
+
+    parser.add_argument('--retry-backoff', type=float, default=1.0, help='Backoff factor to apply between retry attempts when making calls to Databricks API')
+    
     return parser
 
 
@@ -347,6 +352,11 @@ def get_import_parser():
 
     parser.add_argument('--num-parallel', type=int, default=4, help='Number of parallel threads to use to '
                                                                           'export/import')
+
+    parser.add_argument('--retry-total', type=int, default=3, help='Total number or retries when making calls to Databricks API')
+
+    parser.add_argument('--retry-backoff', type=float, default=1.0, help='Backoff factor to apply between retry attempts when making calls to Databricks API')
+
     return parser
 
 
@@ -399,6 +409,8 @@ def build_client_config(profile, url, token, args):
 
     config['use_checkpoint'] = args.use_checkpoint
     config['num_parallel'] = args.num_parallel
+    config['retry_total'] = args.retry_total
+    config['retry_backoff'] = args.retry_backoff
     return config
 
 
@@ -480,5 +492,9 @@ def get_pipeline_parser() -> argparse.ArgumentParser:
 
     parser.add_argument('--num-parallel', type=int, default=4, help='Number of parallel threads to use to '
                                                                           'export/import')
+
+    parser.add_argument('--retry-total', type=int, default=3, help='Total number or retries when making calls to Databricks API')
+
+    parser.add_argument('--retry-backoff', type=float, default=1.0, help='Backoff factor to apply between retry attempts when making calls to Databricks API')
 
     return parser

--- a/export_db.py
+++ b/export_db.py
@@ -51,7 +51,7 @@ def main():
         print("Complete Group Export Time: " + str(timedelta(seconds=end - start)))
         # log the instance profiles
         if scim_c.is_aws():
-            cl_c = ClustersClient(client_config)
+            cl_c = ClustersClient(client_config, checkpoint_service)
             print("Start instance profile logging ...")
             start = timer()
             cl_c.log_instance_profiles()
@@ -102,7 +102,7 @@ def main():
 
     if args.clusters:
         print("Export the cluster configs at {0}".format(now))
-        cl_c = ClustersClient(client_config)
+        cl_c = ClustersClient(client_config, checkpoint_service)
         start = timer()
         # log the cluster json
         cl_c.log_cluster_configs()
@@ -119,7 +119,7 @@ def main():
     if args.jobs:
         print("Export the jobs configs at {0}".format(now))
         start = timer()
-        jobs_c = JobsClient(client_config)
+        jobs_c = JobsClient(client_config, checkpoint_service)
         # log job configs
         jobs_c.log_job_configs()
         end = timer()
@@ -128,7 +128,7 @@ def main():
     if args.pause_all_jobs:
         print("Pause all current jobs {0}".format(now))
         start = timer()
-        jobs_c = JobsClient(client_config)
+        jobs_c = JobsClient(client_config, checkpoint_service)
         # log job configs
         jobs_c.pause_all_jobs()
         end = timer()
@@ -137,7 +137,7 @@ def main():
     if args.unpause_all_jobs:
         print("Unpause all current jobs {0}".format(now))
         start = timer()
-        jobs_c = JobsClient(client_config)
+        jobs_c = JobsClient(client_config, checkpoint_service)
         # log job configs
         jobs_c.pause_all_jobs(False)
         end = timer()
@@ -160,7 +160,7 @@ def main():
     if args.table_acls:
         print("Export the table ACLs configs at {0}".format(now))
         start = timer()
-        table_acls_c = TableACLsClient(client_config)
+        table_acls_c = TableACLsClient(client_config, checkpoint_service)
         if args.database is not None:
             # export table ACLs only for a single database
             notebook_exit_value = table_acls_c.export_table_acls(db_name=args.database)
@@ -184,7 +184,7 @@ def main():
             return
         print("Export the secret scopes configs at {0}".format(now))
         start = timer()
-        sc = SecretsClient(client_config)
+        sc = SecretsClient(client_config, checkpoint_service)
         # log job configs
         sc.log_all_secrets(args.cluster_name)
         sc.log_all_secrets_acls()
@@ -194,7 +194,7 @@ def main():
     if args.mounts:
         print("Export the mount configs at {0}".format(now))
         start = timer()
-        dbfs_c = DbfsClient(client_config)
+        dbfs_c = DbfsClient(client_config, checkpoint_service)
         # log job configs
         dbfs_c.export_dbfs_mounts()
         end = timer()
@@ -277,7 +277,7 @@ def main():
             if not is_user_home_empty:
                 ws_c.export_user_home(username, 'user_exports', num_parallel=args.num_parallel)
         print('Exporting users jobs:')
-        jobs_c = JobsClient(client_config)
+        jobs_c = JobsClient(client_config, checkpoint_service)
         jobs_c.log_job_configs(users_list=user_names)
         end = timer()
         print("Complete User Export Time: " + str(timedelta(seconds=end - start)))

--- a/export_db.py
+++ b/export_db.py
@@ -33,7 +33,7 @@ def main():
     checkpoint_service = CheckpointService(client_config)
 
     if client_config['debug']:
-        print(url, token)
+        print(url)
     now = str(datetime.now())
 
     if args.users:

--- a/import_db.py
+++ b/import_db.py
@@ -27,7 +27,7 @@ def main():
 
     checkpoint_service = CheckpointService(client_config)
     if client_config['debug']:
-        print(url, token)
+        print(url)
     now = str(datetime.now())
 
     if args.users:

--- a/import_db.py
+++ b/import_db.py
@@ -35,7 +35,7 @@ def main():
         scim_c = ScimClient(client_config)
         if client_config['is_aws']:
             print("Start import of instance profiles first to ensure they exist...")
-            cl_c = ClustersClient(client_config)
+            cl_c = ClustersClient(client_config, checkpoint_service)
             start = timer()
             cl_c.import_instance_profiles()
             end = timer()
@@ -85,7 +85,7 @@ def main():
 
     if args.clusters:
         print("Import all cluster configs at {0}".format(now))
-        cl_c = ClustersClient(client_config)
+        cl_c = ClustersClient(client_config, checkpoint_service)
         if client_config['is_aws']:
             print("Start import of instance profiles ...")
             start = timer()
@@ -111,7 +111,7 @@ def main():
     if args.jobs:
         print("Importing the jobs configs at {0}".format(now))
         start = timer()
-        jobs_c = JobsClient(client_config)
+        jobs_c = JobsClient(client_config, checkpoint_service)
         jobs_c.import_job_configs()
         end = timer()
         print("Complete Jobs Export Time: " + str(timedelta(seconds=end - start)))
@@ -137,7 +137,7 @@ def main():
     if args.table_acls:
         print("Importing table acls configs at {0}".format(now))
         start = timer()
-        table_acls_c = TableACLsClient(client_config)
+        table_acls_c = TableACLsClient(client_config, checkpoint_service)
         # log table ACLS configs
         notebook_exit_value = table_acls_c.import_table_acls()
         end = timer()
@@ -146,7 +146,7 @@ def main():
     if args.secrets:
         print("Import secret scopes configs at {0}".format(now))
         start = timer()
-        sc = SecretsClient(client_config)
+        sc = SecretsClient(client_config, checkpoint_service)
         sc.import_all_secrets()
         end = timer()
         print("Complete Secrets Import Time: " + str(timedelta(seconds=end - start)))
@@ -154,7 +154,7 @@ def main():
     if args.pause_all_jobs:
         print("Pause all current jobs {0}".format(now))
         start = timer()
-        jobs_c = JobsClient(client_config)
+        jobs_c = JobsClient(client_config, checkpoint_service)
         # log job configs
         jobs_c.pause_all_jobs()
         end = timer()
@@ -163,7 +163,7 @@ def main():
     if args.unpause_all_jobs:
         print("Unpause all current jobs {0}".format(now))
         start = timer()
-        jobs_c = JobsClient(client_config)
+        jobs_c = JobsClient(client_config, checkpoint_service)
         # log job configs
         jobs_c.pause_all_jobs(False)
         end = timer()
@@ -172,7 +172,7 @@ def main():
     if args.delete_all_jobs:
         print("Delete all current jobs {0}".format(now))
         start = timer()
-        jobs_c = JobsClient(client_config)
+        jobs_c = JobsClient(client_config, checkpoint_service)
         url = jobs_c.get_url()
         response = prompt_for_input(f'\nPlease confirm that you would like to delete jobs from {url} [yes/no]:')
         if response:
@@ -219,7 +219,7 @@ def main():
                 raise ValueError('Overwrite notebooks only supports the SOURCE format. See Rest API docs for details')
         for username in user_names:
             ws_c.import_user_home(username, 'user_exports')
-        jobs_c = JobsClient(client_config)
+        jobs_c = JobsClient(client_config, checkpoint_service)
         # this will only import the groups jobs since we're filtering the jobs during the export process
         print('Importing the groups members jobs:')
         jobs_c.import_job_configs()

--- a/migration_pipeline.py
+++ b/migration_pipeline.py
@@ -49,7 +49,7 @@ def build_pipeline(args) -> Pipeline:
     logging_utils.set_default_logging(client_config['export_dir'])
     if client_config['debug']:
         logging_utils.set_default_logging(client_config['export_dir'], logging.DEBUG)
-        logging.info(url, token)
+        logging.info(url)
 
     checkpoint_service = CheckpointService(client_config)
     if args.export_pipeline:

--- a/migration_pipeline.py
+++ b/migration_pipeline.py
@@ -79,18 +79,18 @@ def build_export_pipeline(client_config, checkpoint_service, args) -> Pipeline:
     completed_pipeline_steps = checkpoint_service.get_checkpoint_key_set(
         wmconstants.WM_EXPORT, wmconstants.MIGRATION_PIPELINE_OBJECT_TYPE)
     pipeline = Pipeline(client_config['export_dir'], completed_pipeline_steps, args.dry_run)
-    export_instance_profiles = pipeline.add_task(InstanceProfileExportTask(client_config, wmconstants.INSTANCE_PROFILES in skip_tasks))
+    export_instance_profiles = pipeline.add_task(InstanceProfileExportTask(client_config, checkpoint_service, wmconstants.INSTANCE_PROFILES in skip_tasks))
     export_users = pipeline.add_task(UserExportTask(client_config, wmconstants.USERS in skip_tasks), [export_instance_profiles])
     export_groups = pipeline.add_task(GroupExportTask(client_config, wmconstants.GROUPS in skip_tasks), [export_users])
     workspace_item_log_export = pipeline.add_task(WorkspaceItemLogExportTask(client_config, checkpoint_service, wmconstants.WORKSPACE_ITEM_LOG in skip_tasks), [export_groups])
     export_workspace_acls = pipeline.add_task(WorkspaceACLExportTask(client_config, checkpoint_service, wmconstants.WORKSPACE_ACLS in skip_tasks), [workspace_item_log_export])
     export_notebooks = pipeline.add_task(NotebookExportTask(client_config, checkpoint_service, wmconstants.NOTEBOOKS in skip_tasks), [workspace_item_log_export])
-    export_secrets = pipeline.add_task(SecretExportTask(client_config, args, wmconstants.SECRETS in skip_tasks), [export_groups])
-    export_clusters = pipeline.add_task(ClustersExportTask(client_config, args, wmconstants.CLUSTERS in skip_tasks), [export_secrets])
-    export_instance_pools = pipeline.add_task(InstancePoolsExportTask(client_config, args, wmconstants.INSTANCE_POOLS in skip_tasks), [export_clusters])
-    export_jobs = pipeline.add_task(JobsExportTask(client_config, args, wmconstants.JOBS in skip_tasks), [export_instance_pools])
+    export_secrets = pipeline.add_task(SecretExportTask(client_config, args, checkpoint_service, wmconstants.SECRETS in skip_tasks), [export_groups])
+    export_clusters = pipeline.add_task(ClustersExportTask(client_config, args, checkpoint_service, wmconstants.CLUSTERS in skip_tasks), [export_secrets])
+    export_instance_pools = pipeline.add_task(InstancePoolsExportTask(client_config, args, checkpoint_service, wmconstants.INSTANCE_POOLS in skip_tasks), [export_clusters])
+    export_jobs = pipeline.add_task(JobsExportTask(client_config, args, checkpoint_service, wmconstants.JOBS in skip_tasks), [export_instance_pools])
     export_metastore = pipeline.add_task(MetastoreExportTask(client_config, checkpoint_service, args, wmconstants.METASTORE in skip_tasks), [export_groups])
-    export_metastore_table_acls = pipeline.add_task(MetastoreTableACLExportTask(client_config, args, wmconstants.METASTORE_TABLE_ACLS in skip_tasks), [export_metastore])
+    export_metastore_table_acls = pipeline.add_task(MetastoreTableACLExportTask(client_config, args, checkpoint_service, wmconstants.METASTORE_TABLE_ACLS in skip_tasks), [export_metastore])
     # FinishExport task is never skipped
     finish_export = pipeline.add_task(FinishExportTask(client_config),
                                       [export_workspace_acls, export_notebooks, export_jobs,
@@ -118,17 +118,17 @@ def build_import_pipeline(client_config, checkpoint_service, args) -> Pipeline:
     completed_pipeline_steps = checkpoint_service.get_checkpoint_key_set(
         wmconstants.WM_IMPORT, wmconstants.MIGRATION_PIPELINE_OBJECT_TYPE)
     pipeline = Pipeline(client_config['export_dir'], completed_pipeline_steps, args.dry_run)
-    import_instance_profiles = pipeline.add_task(InstanceProfileImportTask(client_config, wmconstants.INSTANCE_PROFILES in skip_tasks))
+    import_instance_profiles = pipeline.add_task(InstanceProfileImportTask(client_config, checkpoint_service, wmconstants.INSTANCE_PROFILES in skip_tasks))
     import_users = pipeline.add_task(UserImportTask(client_config, wmconstants.USERS in skip_tasks), [import_instance_profiles])
     import_groups = pipeline.add_task(GroupImportTask(client_config, wmconstants.GROUPS in skip_tasks), [import_users])
     import_notebooks = pipeline.add_task(NotebookImportTask(client_config, checkpoint_service, args, wmconstants.NOTEBOOKS in skip_tasks), [import_groups])
     import_workspace_acls = pipeline.add_task(WorkspaceACLImportTask(client_config, checkpoint_service, wmconstants.WORKSPACE_ACLS in skip_tasks), [import_notebooks])
-    import_secrets = pipeline.add_task(SecretImportTask(client_config, wmconstants.SECRETS in skip_tasks), [import_groups])
-    import_clusters = pipeline.add_task(ClustersImportTask(client_config, args, wmconstants.CLUSTERS in skip_tasks), [import_secrets])
-    import_instance_pools = pipeline.add_task(InstancePoolsImportTask(client_config, args, wmconstants.INSTANCE_POOLS in skip_tasks), [import_clusters])
-    import_jobs = pipeline.add_task(JobsImportTask(client_config, args, wmconstants.JOBS in skip_tasks), [import_instance_pools])
+    import_secrets = pipeline.add_task(SecretImportTask(client_config, checkpoint_service, wmconstants.SECRETS in skip_tasks), [import_groups])
+    import_clusters = pipeline.add_task(ClustersImportTask(client_config, args, checkpoint_service, wmconstants.CLUSTERS in skip_tasks), [import_secrets])
+    import_instance_pools = pipeline.add_task(InstancePoolsImportTask(client_config, args, checkpoint_service, wmconstants.INSTANCE_POOLS in skip_tasks), [import_clusters])
+    import_jobs = pipeline.add_task(JobsImportTask(client_config, args, checkpoint_service, wmconstants.JOBS in skip_tasks), [import_instance_pools])
     import_metastore = pipeline.add_task(MetastoreImportTask(client_config, checkpoint_service, args, wmconstants.METASTORE in skip_tasks), [import_groups])
-    import_metastore_table_acls = pipeline.add_task(MetastoreTableACLImportTask(client_config, args, wmconstants.METASTORE_TABLE_ACLS in skip_tasks), [import_metastore])
+    import_metastore_table_acls = pipeline.add_task(MetastoreTableACLImportTask(client_config, args, checkpoint_service, wmconstants.METASTORE_TABLE_ACLS in skip_tasks), [import_metastore])
     return pipeline
 
 

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -15,14 +15,15 @@ import wmconstants
 
 class InstanceProfileExportTask(AbstractTask):
     """Task that exports instance profiles."""
-    def __init__(self, client_config, skip=False):
+    def __init__(self, client_config, checkpoint_service, skip=False):
         super().__init__("export_instance_profiles", wmconstants.WM_EXPORT, wmconstants.INSTANCE_PROFILE_OBJECT, skip)
         self.client_config = client_config
+        self.checkpoint_service = checkpoint_service
 
     def run(self):
         scim_c = ScimClient(self.client_config)
         if scim_c.is_aws():
-            cl_c = ClustersClient(self.client_config)
+            cl_c = ClustersClient(self.client_config, self.checkpoint_service)
             cl_c.log_instance_profiles()
 
 
@@ -52,13 +53,14 @@ class GroupExportTask(AbstractTask):
 
 class InstanceProfileImportTask(AbstractTask):
     """Task that imports instance profiles."""
-    def __init__(self, client_config, skip=False):
+    def __init__(self, client_config, checkpoint_service, skip=False):
         super().__init__("import_instance_profiles", wmconstants.WM_IMPORT, wmconstants.INSTANCE_PROFILE_OBJECT, skip)
         self.client_config = client_config
+        self.checkpoint_service = checkpoint_service
 
     def run(self):
         if self.client_config['is_aws']:
-            cl_c = ClustersClient(self.client_config)
+            cl_c = ClustersClient(self.client_config, self.checkpoint_service)
             cl_c.import_instance_profiles()
 
 
@@ -91,7 +93,6 @@ class WorkspaceItemLogExportTask(AbstractTask):
     The behavior is equivalent to `$ python export_db.py --workspace`, which lives in main function of
     export_db.py.
     """
- 
     def __init__(self, client_config, checkpoint_service, skip=False):
         super().__init__("export_workspace_items_log", wmconstants.WM_EXPORT, wmconstants.WORKSPACE_NOTEBOOK_PATH_OBJECT, skip)
         self.client_config = client_config
@@ -180,13 +181,14 @@ class NotebookImportTask(AbstractTask):
 
 class ClustersExportTask(AbstractTask):
     """Task that exports all clusters."""
-    def __init__(self, client_config, args, skip=False):
+    def __init__(self, client_config, args, checkpoint_service, skip=False):
         super().__init__("export_clusters", wmconstants.WM_EXPORT, wmconstants.CLUSTER_OBJECT, skip)
         self.client_config = client_config
         self.args = args
+        self.checkpoint_service = checkpoint_service
 
     def run(self):
-        cl_c = ClustersClient(self.client_config)
+        cl_c = ClustersClient(self.client_config, self.checkpoint_service)
         # log the cluster json
         cl_c.log_cluster_configs()
         cl_c.log_cluster_policies()
@@ -194,38 +196,41 @@ class ClustersExportTask(AbstractTask):
 
 class InstancePoolsExportTask(AbstractTask):
     """Task that exports all instance pools."""
-    def __init__(self, client_config, args, skip=False):
+    def __init__(self, client_config, args, checkpoint_service, skip=False):
         super().__init__("export_instance_pools", wmconstants.WM_EXPORT, wmconstants.INSTANCE_POOL_OBJECT, skip)
         self.client_config = client_config
         self.args = args
+        self.checkpoint_service = checkpoint_service
 
     def run(self):
-        cl_c = ClustersClient(self.client_config)
+        cl_c = ClustersClient(self.client_config, self.checkpoint_service)
         cl_c.log_instance_pools()
 
 
 class ClustersImportTask(AbstractTask):
     """Task that imports all clusters."""
-    def __init__(self, client_config, args, skip=False):
+    def __init__(self, client_config, args, checkpoint_service, skip=False):
         super().__init__("import_clusters", wmconstants.WM_IMPORT, wmconstants.CLUSTER_OBJECT, skip)
         self.client_config = client_config
         self.args = args
+        self.checkpoint_service = checkpoint_service
 
     def run(self):
-        cl_c = ClustersClient(self.client_config)
+        cl_c = ClustersClient(self.client_config, self.checkpoint_service)
         cl_c.import_cluster_policies()
         cl_c.import_cluster_configs()
 
 
 class InstancePoolsImportTask(AbstractTask):
     """Task that imports all instance pools."""
-    def __init__(self, client_config, args, skip=False):
+    def __init__(self, client_config, args, checkpoint_service, skip=False):
         super().__init__("import_instance_pools", wmconstants.WM_IMPORT, wmconstants.INSTANCE_POOL_OBJECT, skip)
         self.client_config = client_config
         self.args = args
+        self.checkpoint_service = checkpoint_service
 
     def run(self):
-        cl_c = ClustersClient(self.client_config)
+        cl_c = ClustersClient(self.client_config, self.checkpoint_service)
         cl_c.import_instance_pools()
 
 
@@ -235,13 +240,14 @@ class JobsExportTask(AbstractTask):
     The behavior is equivalent to `$ python export_db.py --jobs`, which lives in main function of
     export_db.py.
     """
-    def __init__(self, client_config, args, skip=False):
+    def __init__(self, client_config, args, checkpoint_service, skip=False):
         super().__init__("export_jobs", wmconstants.WM_EXPORT, wmconstants.JOB_OBJECT, skip)
         self.client_config = client_config
         self.args = args
+        self.checkpoint_service = checkpoint_service
 
     def run(self):
-        jobs_c = JobsClient(self.client_config)
+        jobs_c = JobsClient(self.client_config, self.checkpoint_service)
         jobs_c.log_job_configs()
 
 
@@ -251,13 +257,14 @@ class JobsImportTask(AbstractTask):
     The behavior is equivalent to `$ python import_db.py --jobs`, which lives in main function of
     import_db.py.
     """
-    def __init__(self, client_config, args, skip=False):
+    def __init__(self, client_config, args, checkpoint_service, skip=False):
         super().__init__("import_jobs", wmconstants.WM_IMPORT, wmconstants.JOB_OBJECT, skip)
         self.client_config = client_config
         self.args = args
+        self.checkpoint_service = checkpoint_service
 
     def run(self):
-        jobs_c = JobsClient(self.client_config)
+        jobs_c = JobsClient(self.client_config, self.checkpoint_service)
         jobs_c.import_job_configs()
 
 
@@ -305,13 +312,14 @@ class MetastoreTableACLExportTask(AbstractTask):
     The behavior is equivalent to `$ python export_db.py --table-acls`, which lives in main function of
     export_db.py.
     """
-    def __init__(self, client_config, args, skip=False):
+    def __init__(self, client_config, args, checkpoint_service, skip=False):
         super().__init__("export_metastore_table_acls", wmconstants.WM_EXPORT, wmconstants.METASTORE_TABLES_ACL, skip)
         self.client_config = client_config
         self.args = args
+        self.checkpoint_service = checkpoint_service
 
     def run(self):
-        table_acls_c = TableACLsClient(self.client_config)
+        table_acls_c = TableACLsClient(self.client_config, self.checkpoint_service)
         notebook_exit_value = table_acls_c.export_table_acls(db_name='')
         if notebook_exit_value['num_errors'] == 0:
             print("Table ACL export completed successfully without errors")
@@ -329,13 +337,14 @@ class MetastoreTableACLImportTask(AbstractTask):
     The behavior is equivalent to `$ python import_db.py --table-acls`, which lives in main function of
     import_db.py.
     """
-    def __init__(self, client_config, args, skip=False):
+    def __init__(self, client_config, args, checkpoint_service, skip=False):
         super().__init__("import_metastore_table_acls", wmconstants.WM_IMPORT, wmconstants.METASTORE_TABLES_ACL, skip)
         self.client_config = client_config
         self.args = args
+        self.checkpoint_service = checkpoint_service
 
     def run(self):
-        table_acls_c = TableACLsClient(self.client_config)
+        table_acls_c = TableACLsClient(self.client_config, self.checkpoint_service)
         table_acls_c.import_table_acls()
 
 
@@ -344,13 +353,14 @@ class SecretExportTask(AbstractTask):
 
     The behavior is equivalent to `$ python export_db.py --secrets --cluster-name $clusterName
     """
-    def __init__(self, client_config, args, skip=False):
+    def __init__(self, client_config, args, checkpoint_service, skip=False):
         super().__init__("export_secrets", wmconstants.WM_EXPORT, wmconstants.SECRET_OBJECT, skip)
         self.client_config = client_config
         self.args = args
+        self.checkpoint_service = checkpoint_service
 
     def run(self):
-        secrets_c = SecretsClient(self.client_config)
+        secrets_c = SecretsClient(self.client_config, self.checkpoint_service)
         secrets_c.log_all_secrets(cluster_name=self.args.cluster_name)
         secrets_c.log_all_secrets_acls()
 
@@ -360,12 +370,13 @@ class SecretImportTask(AbstractTask):
 
     The behavior is equivalent to `$ python import_db.py --secrets`
     """
-    def __init__(self, client_config, skip=False):
+    def __init__(self, client_config, checkpoint_service, skip=False):
         super().__init__("import_secrets", wmconstants.WM_IMPORT, wmconstants.SECRET_OBJECT, skip)
         self.client_config = client_config
+        self.checkpoint_service = checkpoint_service
 
     def run(self):
-        secrets_c = SecretsClient(self.client_config)
+        secrets_c = SecretsClient(self.client_config, self.checkpoint_service)
         secrets_c.import_all_secrets()
 
 

--- a/test/thread_safe_writer_test.py
+++ b/test/thread_safe_writer_test.py
@@ -2,6 +2,7 @@ import unittest
 import filecmp
 import os
 from thread_safe_writer import ThreadSafeWriter
+from threading_utils import propagate_exceptions
 import concurrent.futures
 
 class ThreadSafeWriterTest(unittest.TestCase):
@@ -42,6 +43,7 @@ class ThreadSafeWriterTest(unittest.TestCase):
         with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
             futures = [executor.submit(file_writer.write, str(data) + "\n") for data in list_to_write]
             concurrent.futures.wait(futures)
+            propagate_exceptions(futures)
 
         file_writer.close()
 

--- a/test/threading_utils_test.py
+++ b/test/threading_utils_test.py
@@ -1,0 +1,25 @@
+import unittest
+from threading_utils import propagate_exceptions
+import concurrent.futures
+from concurrent.futures import ThreadPoolExecutor
+
+class MyBadException(Exception):
+    pass
+
+class ThreadingUtilsTest(unittest.TestCase):
+    def test_should_propagate_exception(self):
+        def do_something_good():
+            return 'howdy'
+
+        def do_something_bad():
+            raise MyBadException('something bad happened')
+
+        def run_stuff():
+            fut1 = ThreadPoolExecutor(2).submit(do_something_good)
+            fut2 = ThreadPoolExecutor(2).submit(do_something_bad)
+            return fut1, fut2
+
+        with self.assertRaises(MyBadException):
+            futures = run_stuff()
+            concurrent.futures.wait(futures)
+            propagate_exceptions(futures)

--- a/threading_utils.py
+++ b/threading_utils.py
@@ -1,0 +1,3 @@
+def propagate_exceptions(futures):
+    # Calling result() on a future whose execution raised an exception will propagate the exception to the caller
+    [future.result() for future in futures]


### PR DESCRIPTION
This PR supports http retry logic for making requests to the Databricks API.

The following two command line parameters were added:

```
--retry-total RETRY_TOTAL
Total number or retries when making calls to Databricks API

--retry-backoff RETRY_BACKOFF
Backoff factor to apply between retry attempts when making calls to Databricks API
```

This PR also refactored the code to propagate exceptions that are thrown by threads.
Unit test: `python -m unittest discover -s test -p 'thread*_test.py'`

Manual test of export which successfully exported 90,000 notebooks.
```
date; time python migration_pipeline.py --export-pipeline --profile old --use-checkpoint --debug --num-parallel 20 --retry-total=20 --retry-backoff=1.0 --notebook-format SOURCE --skip-tasks 'metastore' 'metastore_table_acls' 2>&1 | tee -a tmp.txt
```

Manual test of import which successfully imported 90,000 notebooks with many retries of http 429:
```
date; time python migration_pipeline.py --import-pipeline --profile scratch-green --session M20220311165759 --archive-missing --use-checkpoint --debug --num-parallel 8 --retry-total=20 --retry-backoff=1.0 --notebook-format SOURCE --overwrite-notebooks --skip-tasks 'metastore' 'metastore_table_acls' 'workspace_acls' 2>&1 | tee -a tmp.txt
```