### PR TITLE
[Issue 126] Add http retry logic

### DIFF
--- a/dbclient/MLFlowClient.py
+++ b/dbclient/MLFlowClient.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from timeit import default_timer as timer
 import logging
 import logging_utils
+from threading_utils import propagate_exceptions
 from mlflow.tracking import MlflowClient
 from mlflow.entities import ViewType
 from mlflow.exceptions import RestException
@@ -54,6 +55,7 @@ class MLFlowClient:
                 with ThreadPoolExecutor(max_workers=num_parallel) as executor:
                     futures = [executor.submit(self._create_experiment, experiment_str, id_map_thread_safe_writer, mlflow_experiments_checkpointer, error_logger) for experiment_str in fp]
                     concurrent.futures.wait(futures)
+                    propagate_exceptions(futures)
         finally:
             id_map_thread_safe_writer.close()
 

--- a/dbclient/WorkspaceClient.py
+++ b/dbclient/WorkspaceClient.py
@@ -4,6 +4,7 @@ import wmconstants
 import concurrent
 from concurrent.futures import ThreadPoolExecutor
 from thread_safe_writer import ThreadSafeWriter
+from threading_utils import propagate_exceptions
 from timeit import default_timer as timer
 from datetime import timedelta
 import logging_utils
@@ -473,10 +474,8 @@ class WorkspaceClient(dbclient):
         with open(read_log_path, 'r') as read_fp:
             with ThreadPoolExecutor(max_workers=num_parallel) as executor:
                 futures = [executor.submit(_acl_log_helper, json_data) for json_data in read_fp]
-                results = concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
-                for result in results.done:
-                    if result.exception() is not None:
-                        raise result.exception()
+                concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
+                propagate_exceptions(futures)
 
     def log_all_workspace_acls(self, workspace_log_file='user_workspace.log',
                                dir_log_file='user_dirs.log',
@@ -567,20 +566,16 @@ class WorkspaceClient(dbclient):
         with open(notebook_acl_logs) as nb_acls_fp:
             with ThreadPoolExecutor(max_workers=num_parallel) as executor:
                 futures = [executor.submit(self.apply_acl_on_object, nb_acl_str, acl_notebooks_error_logger) for nb_acl_str in nb_acls_fp]
-                results = concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
-                for result in results.done:
-                    if result.exception() is not None:
-                        raise result.exception()
+                concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
+                propagate_exceptions(futures)
 
         acl_dir_error_logger = logging_utils.get_error_logger(
             wmconstants.WM_IMPORT, wmconstants.WORKSPACE_DIRECTORY_ACL_OBJECT, self.get_export_dir())
         with open(dir_acl_logs) as dir_acls_fp:
             with ThreadPoolExecutor(max_workers=num_parallel) as executor:
                 futures = [executor.submit(self.apply_acl_on_object, dir_acl_str, acl_dir_error_logger) for dir_acl_str in dir_acls_fp]
-                results = concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
-                for result in results.done:
-                    if result.exception() is not None:
-                        raise result.exception()
+                concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
+                propagate_exceptions(futures)
         print("Completed import ACLs of Notebooks and Directories")
 
     def get_current_users(self):
@@ -735,14 +730,10 @@ class WorkspaceClient(dbclient):
 
             with ThreadPoolExecutor(max_workers=num_parallel) as executor:
                 futures = [executor.submit(_file_upload_helper, file) for file in files]
-                results = concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
-                for result in results.done:
-                    if result.exception() is not None:
-                        raise result.exception()
+                concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
+                propagate_exceptions(futures)
 
         with ThreadPoolExecutor(max_workers=num_parallel) as executor:
             futures = [executor.submit(_upload_all_files, walk[0], walk[1], walk[2]) for walk in self.walk(src_dir)]
-            results = concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
-            for result in results.done:
-                if result.exception() is not None:
-                    raise result.exception()
+            concurrent.futures.wait(futures, return_when="FIRST_EXCEPTION")
+            propagate_exceptions(futures)

--- a/dbclient/dbclient.py
+++ b/dbclient/dbclient.py
@@ -37,10 +37,17 @@ class dbclient:
     Rest API Wrapper for Databricks APIs
     """
     # set of http error codes to retry
-    http_retry_codes = [429, 503]
+    # 429: Too Many Requests
+    # 503: Service Unavailable
+    # 504: Gateway Timeout
+    http_retry_codes = [429, 503, 504]
+
     # set of http error codes to throw an exception if hit. Handles client and auth errors.
     # Also include the retry error codes in case all retry attempts fail.
-    http_error_codes = [401, 500, 502, 504] + http_retry_codes
+    # 401: Unauthorized
+    # 500: Internal Server Error
+    # 502: Bad Gateway
+    http_error_codes = [401, 500, 502] + http_retry_codes
 
     def __init__(self, configs):
         self._profile = configs['profile']

--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -222,6 +222,11 @@ def get_export_parser():
 
     parser.add_argument('--num-parallel', type=int, default=4, help='Number of parallel threads to use to '
                                                                           'export/import')
+
+    parser.add_argument('--retry-total', type=int, default=3, help='Total number or retries when making calls to Databricks API')
+
+    parser.add_argument('--retry-backoff', type=float, default=1.0, help='Backoff factor to apply between retry attempts when making calls to Databricks API')
+    
     return parser
 
 
@@ -347,6 +352,11 @@ def get_import_parser():
 
     parser.add_argument('--num-parallel', type=int, default=4, help='Number of parallel threads to use to '
                                                                           'export/import')
+
+    parser.add_argument('--retry-total', type=int, default=3, help='Total number or retries when making calls to Databricks API')
+
+    parser.add_argument('--retry-backoff', type=float, default=1.0, help='Backoff factor to apply between retry attempts when making calls to Databricks API')
+
     return parser
 
 
@@ -399,6 +409,8 @@ def build_client_config(profile, url, token, args):
 
     config['use_checkpoint'] = args.use_checkpoint
     config['num_parallel'] = args.num_parallel
+    config['retry_total'] = args.retry_total
+    config['retry_backoff'] = args.retry_backoff
     return config
 
 
@@ -480,5 +492,9 @@ def get_pipeline_parser() -> argparse.ArgumentParser:
 
     parser.add_argument('--num-parallel', type=int, default=4, help='Number of parallel threads to use to '
                                                                           'export/import')
+
+    parser.add_argument('--retry-total', type=int, default=3, help='Total number or retries when making calls to Databricks API')
+
+    parser.add_argument('--retry-backoff', type=float, default=1.0, help='Backoff factor to apply between retry attempts when making calls to Databricks API')
 
     return parser

--- a/export_db.py
+++ b/export_db.py
@@ -33,7 +33,7 @@ def main():
     checkpoint_service = CheckpointService(client_config)
 
     if client_config['debug']:
-        print(url, token)
+        print(url)
     now = str(datetime.now())
 
     if args.users:

--- a/import_db.py
+++ b/import_db.py
@@ -27,7 +27,7 @@ def main():
 
     checkpoint_service = CheckpointService(client_config)
     if client_config['debug']:
-        print(url, token)
+        print(url)
     now = str(datetime.now())
 
     if args.users:

--- a/migration_pipeline.py
+++ b/migration_pipeline.py
@@ -49,7 +49,7 @@ def build_pipeline(args) -> Pipeline:
     logging_utils.set_default_logging(client_config['export_dir'])
     if client_config['debug']:
         logging_utils.set_default_logging(client_config['export_dir'], logging.DEBUG)
-        logging.info(url, token)
+        logging.info(url)
 
     checkpoint_service = CheckpointService(client_config)
     if args.export_pipeline:

--- a/test/thread_safe_writer_test.py
+++ b/test/thread_safe_writer_test.py
@@ -2,6 +2,7 @@ import unittest
 import filecmp
 import os
 from thread_safe_writer import ThreadSafeWriter
+from threading_utils import propagate_exceptions
 import concurrent.futures
 
 class ThreadSafeWriterTest(unittest.TestCase):
@@ -42,6 +43,7 @@ class ThreadSafeWriterTest(unittest.TestCase):
         with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
             futures = [executor.submit(file_writer.write, str(data) + "\n") for data in list_to_write]
             concurrent.futures.wait(futures)
+            propagate_exceptions(futures)
 
         file_writer.close()
 

--- a/test/threading_utils_test.py
+++ b/test/threading_utils_test.py
@@ -1,0 +1,25 @@
+import unittest
+from threading_utils import propagate_exceptions
+import concurrent.futures
+from concurrent.futures import ThreadPoolExecutor
+
+class MyBadException(Exception):
+    pass
+
+class ThreadingUtilsTest(unittest.TestCase):
+    def test_should_propagate_exception(self):
+        def do_something_good():
+            return 'howdy'
+
+        def do_something_bad():
+            raise MyBadException('something bad happened')
+
+        def run_stuff():
+            fut1 = ThreadPoolExecutor(2).submit(do_something_good)
+            fut2 = ThreadPoolExecutor(2).submit(do_something_bad)
+            return fut1, fut2
+
+        with self.assertRaises(MyBadException):
+            futures = run_stuff()
+            concurrent.futures.wait(futures)
+            propagate_exceptions(futures)

--- a/threading_utils.py
+++ b/threading_utils.py
@@ -1,0 +1,3 @@
+def propagate_exceptions(futures):
+    # Calling result() on a future whose execution raised an exception will propagate the exception to the caller
+    [future.result() for future in futures]

--- a/threading_utils.py
+++ b/threading_utils.py
@@ -1,3 +1,4 @@
 def propagate_exceptions(futures):
     # Calling result() on a future whose execution raised an exception will propagate the exception to the caller
     [future.result() for future in futures]
+    

--- a/threading_utils.py
+++ b/threading_utils.py
@@ -1,4 +1,3 @@
 def propagate_exceptions(futures):
     # Calling result() on a future whose execution raised an exception will propagate the exception to the caller
     [future.result() for future in futures]
-    


### PR DESCRIPTION
This PR supports http retry logic for making requests to the Databricks API.

The following two command line parameters were added:

```
--retry-total RETRY_TOTAL
Total number or retries when making calls to Databricks API

--retry-backoff RETRY_BACKOFF
Backoff factor to apply between retry attempts when making calls to Databricks API
```

This PR also refactored the code to propagate exceptions that are thrown by threads.
Unit test: `python -m unittest discover -s test -p 'thread*_test.py'`

Manual test of export which successfully exported 90,000 notebooks.
```
date; time python migration_pipeline.py --export-pipeline --profile old --use-checkpoint --debug --num-parallel 20 --retry-total=20 --retry-backoff=1.0 --notebook-format SOURCE --skip-tasks 'metastore' 'metastore_table_acls' 2>&1 | tee -a tmp.txt
```

Manual test of import which successfully imported 90,000 notebooks with many retries of http 429:
```
date; time python migration_pipeline.py --import-pipeline --profile scratch-green --session M20220311165759 --archive-missing --use-checkpoint --debug --num-parallel 8 --retry-total=20 --retry-backoff=1.0 --notebook-format SOURCE --overwrite-notebooks --skip-tasks 'metastore' 'metastore_table_acls' 'workspace_acls' 2>&1 | tee -a tmp.txt
```