### PR TITLE
[Issue 139] Set job owner to admin user when original job owner is obsolete user

### DIFF
--- a/dbclient/JobsClient.py
+++ b/dbclient/JobsClient.py
@@ -187,6 +187,7 @@ class JobsClient(ClustersClient):
 
 
         # update the jobs with their ACLs
+        admin_user_name = self.whoami()
         with open(acl_jobs_log, 'r') as acl_fp:
             job_id_by_name = self.get_job_id_by_name()
             for line in acl_fp:
@@ -197,7 +198,7 @@ class JobsClient(ClustersClient):
                 job_path = f'jobs/{current_job_id}'  # contains `/jobs/{job_id}` path
                 api = f'/preview/permissions/{job_path}'
                 # get acl permissions for jobs
-                acl_perms = self.build_acl_args(acl_conf['access_control_list'], True)
+                acl_perms = self.build_acl_args(acl_conf['access_control_list'], True, admin_user_name)
                 acl_create_args = {'access_control_list': acl_perms}
                 acl_resp = self.patch(api, acl_create_args)
                 if not logging_utils.log_reponse_error(error_logger, acl_resp) and 'object_id' in acl_conf:

--- a/dbclient/dbclient.py
+++ b/dbclient/dbclient.py
@@ -287,7 +287,7 @@ class dbclient:
         user_name = self.get('/preview/scim/v2/Me').get('userName')
         return user_name
 
-    def build_acl_args(self, full_acl_list, is_jobs=False):
+    def build_acl_args(self, full_acl_list, is_jobs=False, admin_user_name=None):
         """
         Take the ACL json and return a json that corresponds to the proper input with permission level one level higher
         { 'acl': [ { (user_name, group_name): {'permission_level': '*'}, ... ] }
@@ -312,9 +312,11 @@ class dbclient:
                         current_owner = member.get('group_name')
 
         if is_jobs:
-            me = self.whoami()
-            if current_owner != me:
-                update_admin = {'user_name': self.whoami(),
+            # set current_owner to admin if current_owner is empty
+            # current_owner is empty when original job owner is obsolete user
+            current_owner = current_owner or admin_user_name
+            if current_owner != admin_user_name:
+                update_admin = {'user_name': admin_user_name,
                                 'permission_level': 'CAN_MANAGE'}
                 acls_list.append(update_admin)
         return acls_list


### PR DESCRIPTION
This PR handles setting ACLs for a job whose original owner was an obsolete user. In this case the job will be owned by the admin user whose credentials are tied to the databricks token that is being used to run the import.

There is also an optimization to only ask for the admin username once, instead of each time we apply job ACLs.

This PR has been manually tested by running a job export and job import.