### PR TITLE
fixing the MTJ migration with all dependency

### DIFF
--- a/dbclient/JobsClient.py
+++ b/dbclient/JobsClient.py
@@ -1,5 +1,6 @@
 import os
 import logging
+from tabnanny import verbose
 import logging_utils
 from dbclient import *
 import wmconstants
@@ -27,6 +28,8 @@ class JobsClient(ClustersClient):
         res = self.get("/jobs/list", print_json, version='2.0')
         for job in res.get('jobs', []):
             jobsById[job.get('job_id')] = job
+            
+        
 
         limit = 25 # max limit supported by the API
         offset = 0
@@ -40,8 +43,11 @@ class JobsClient(ClustersClient):
             has_more = res.get('has_more')
             for job in res.get('jobs', []):
                 jobId = job.get('job_id')
+                has_more = res.get('has_more')
+                lens = len(job.get("settings").get('tasks'))
                 # only replaces "real" MULTI_TASK jobs, as they contain the task definitions.
-                if jobsById[jobId].get('format') == 'MULTI_TASK':
+                ## checking the tasks array length as Api 2.1 has that for every type of JOB
+                if lens > 1:
                     jobsById[jobId] = job
         return jobsById.values()
 
@@ -56,7 +62,7 @@ class JobsClient(ClustersClient):
             job_ids[job['settings']['name']] = job['job_id']
         return job_ids
 
-    def update_imported_job_names(self, error_logger, checkpoint_job_configs_set):
+    def update_imported_job_names(self):
         # loop through and update the job names to remove the custom delimiter + job_id suffix
         current_jobs_list = self.get_jobs_list()
         for job in current_jobs_list:
@@ -64,17 +70,12 @@ class JobsClient(ClustersClient):
             job_name = job['settings']['name']
             # job name was set to `old_job_name:::{job_id}` to support duplicate job names
             # we need to parse the old job name and update the current jobs
-            if checkpoint_job_configs_set.contains(job_name):
-                continue
             old_job_name = job_name.split(':::')[0]
             new_settings = {'name': old_job_name}
             update_args = {'job_id': job_id, 'new_settings': new_settings}
-            logging.info(f'Updating job name: {update_args}')
+            print('Updating job name:', update_args)
             resp = self.post('/jobs/update', update_args)
-            if not logging_utils.log_reponse_error(error_logger, resp):
-                checkpoint_job_configs_set.write(job_name)
-            else:
-                raise RuntimeError("Import job has failed. Refer to the previous log messages to investigate.")
+
 
     def log_job_configs(self, users_list=[], log_file='jobs.log', acl_file='acl_jobs.log'):
         """
@@ -110,32 +111,40 @@ class JobsClient(ClustersClient):
                     job_perms['job_name'] = new_job_name
                     acl_fp.write(json.dumps(job_perms) + '\n')
 
-    def import_job_configs(self, log_file='jobs.log', acl_file='acl_jobs.log'):
+    def import_job_configs(self, log_file='jobs.log', acl_file='acl_jobs.log', replace_jobs=False):
         jobs_log = self.get_export_dir() + log_file
         acl_jobs_log = self.get_export_dir() + acl_file
-        error_logger = logging_utils.get_error_logger(
-            wmconstants.WM_IMPORT, wmconstants.JOB_OBJECT, self.get_export_dir())
         if not os.path.exists(jobs_log):
-            logging.info("No job configurations to import.")
+            print("No job configurations to import.")
             return
         # get an old cluster id to new cluster id mapping object
         cluster_mapping = self.get_cluster_id_mapping()
         old_2_new_policy_ids = self.get_new_policy_id_dict()  # dict { old_policy_id : new_policy_id }
-        checkpoint_job_configs_set = self._checkpoint_service.get_checkpoint_key_set(
-            wmconstants.WM_IMPORT, wmconstants.JOB_OBJECT)
+        jobs_to_replace = []
 
-        def adjust_ids_for_cluster(settings): #job_settings or task_settings
+        def adjust_ids_for_cluster(settings,tasksLength): #job_settings or task_settings
             if 'existing_cluster_id' in settings:
                 old_cid = settings['existing_cluster_id']
                 # set new cluster id for existing cluster attribute
                 new_cid = cluster_mapping.get(old_cid, None)
                 if not new_cid:
-                    logging.info("Existing cluster has been removed. Resetting job to use new cluster.")
+                    print("Existing cluster has been removed. Resetting job to use new cluster.")
                     settings.pop('existing_cluster_id')
                     settings['new_cluster'] = self.get_jobs_default_cluster_conf()
                 else:
                     settings['existing_cluster_id'] = new_cid
-            else:  # new cluster config
+            elif tasksLength > 1:  # new cluster config, With API2.1, job_cluster_key need to be checked for existing clusers in case of MTJ
+                if 'job_cluster_key' in settings:
+                    old_cid = settings['job_cluster_key']
+                    # set new cluster id for existing cluster attribute
+                    new_cid = cluster_mapping.get(old_cid, None)
+                    if not new_cid:
+                        logging.info("Existing cluster has been removed. Resetting job to use new cluster.")
+                        settings.pop('job_cluster_key')
+                        settings['new_cluster'] = self.get_jobs_default_cluster_conf()
+                    else:
+                        settings['existing_cluster_id'] = new_cid
+            elif tasksLength == 1:  # new cluster config
                 cluster_conf = settings['new_cluster']
                 if 'policy_id' in cluster_conf:
                     old_policy_id = cluster_conf['policy_id']
@@ -150,49 +159,39 @@ class JobsClient(ClustersClient):
         with open(jobs_log, 'r') as fp:
             for line in fp:
                 job_conf = json.loads(line)
-                # need to do str(...), otherwise the job_id is recognized as integer which becomes
-                # str vs int which never matches.
-                # (in which case, the checkpoint never recognizes that the job_id is already checkpointed)
-                if 'job_id' in job_conf and checkpoint_job_configs_set.contains(str(job_conf['job_id'])):
-                    continue
                 job_creator = job_conf.get('creator_user_name', '')
                 job_settings = job_conf['settings']
                 job_schedule = job_settings.get('schedule', None)
+                tasksLength = len(job_settings.get('tasks', []))
                 if job_schedule:
                     # set all imported jobs as paused
                     job_schedule['pause_status'] = 'PAUSED'
                     job_settings['schedule'] = job_schedule
                 if 'format' not in job_settings or job_settings.get('format') == 'SINGLE_TASK':
-                    adjust_ids_for_cluster(job_settings)
+                    adjust_ids_for_cluster(job_settings,tasksLength)
                 else:
                     for task_settings in job_settings.get('tasks', []):
-                        adjust_ids_for_cluster(task_settings)
+                        print("IMPPPP!!! :",task_settings)
+                        adjust_ids_for_cluster(task_settings,tasksLength)
 
-                logging.info("Current Job Name: {0}".format(job_conf['settings']['name']))
+                print("Current Job Name: {0}".format(job_conf['settings']['name']))
                 # creator can be none if the user is no longer in the org. see our docs page
+                creator_user_name = job_conf.get('creator_user_name', None)
                 create_resp = self.post('/jobs/create', job_settings)
-                if logging_utils.check_error(create_resp):
-                    logging.info("Resetting job to use default cluster configs due to expired configurations.")
+                if 'error_code' in create_resp:
+                    print("Resetting job to use default cluster configs due to expired configurations.")
                     job_settings['new_cluster'] = self.get_jobs_default_cluster_conf()
                     create_resp_retry = self.post('/jobs/create', job_settings)
-                    if not logging_utils.log_reponse_error(error_logger, create_resp_retry):
-                        if 'job_id' in job_conf:
-                            checkpoint_job_configs_set.write(job_conf["job_id"])
-                    else:
-                        raise RuntimeError("Import job has failed. Refer to the previous log messages to investigate.")
-
-                else:
-                    if 'job_id' in job_conf:
-                        checkpoint_job_configs_set.write(job_conf["job_id"])
-
-
+                # remove old job
+                if(replace_jobs):
+                    jobs_to_replace.append(job_settings['name'].split(':::')[0])
         # update the jobs with their ACLs
+        job_id_by_name = self.get_job_id_by_name()
+        
         with open(acl_jobs_log, 'r') as acl_fp:
-            job_id_by_name = self.get_job_id_by_name()
             for line in acl_fp:
                 acl_conf = json.loads(line)
-                if 'object_id' in acl_conf and checkpoint_job_configs_set.contains(acl_conf['object_id']):
-                    continue
+                ## remove the subscript [0]         
                 current_job_id = job_id_by_name[acl_conf['job_name']]
                 job_path = f'jobs/{current_job_id}'  # contains `/jobs/{job_id}` path
                 api = f'/preview/permissions/{job_path}'
@@ -200,12 +199,14 @@ class JobsClient(ClustersClient):
                 acl_perms = self.build_acl_args(acl_conf['access_control_list'], True)
                 acl_create_args = {'access_control_list': acl_perms}
                 acl_resp = self.patch(api, acl_create_args)
-                if not logging_utils.log_reponse_error(error_logger, acl_resp) and 'object_id' in acl_conf:
-                    checkpoint_job_configs_set.write(acl_conf['object_id'])
-                else:
-                    raise RuntimeError("Import job has failed. Refer to the previous log messages to investigate.")
+                print(acl_resp)
+        if(replace_jobs):
+            # remove old jobs
+            for job_name in jobs_to_replace:
+                for job_id in job_id_by_name[job_name]:
+                    self.post('/jobs/delete', {'job_id': job_id})
         # update the imported job names
-        self.update_imported_job_names(error_logger, checkpoint_job_configs_set)
+        self.update_imported_job_names()
 
     def pause_all_jobs(self, pause=True):
         job_list = self.get_jobs_list()


### PR DESCRIPTION
The API2.1 when exporting the jobs does not actually check for the actual multi-task job, as in API2.1 every job is multi-task. I tried to fetch the real multi-task job by using the length of the tasks array. Another modification is while importing, adding the code to check for the existing cluster and if not present then creating the new cluster with the default configuration.