### PR TITLE
[PLAT-46721] Export mlflow_runs only start_time >= start-date

### DIFF
--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -1,4 +1,5 @@
 import argparse
+from datetime import datetime, timedelta
 import configparser
 import wmconstants
 from enum import Enum
@@ -29,6 +30,13 @@ class ValidateSkipTasks(argparse.Action):
                 raise ValueError(f"invalid task {task}. Skipped tasks must come from {valid_tasks}.")
         setattr(args, self.dest, values)
 
+
+def valid_date(s):
+    try:
+        return datetime.strptime(s, "%Y-%m-%d")
+    except ValueError:
+        msg = "not a valid date: {0!r}. It must be in YYYY-MM-DD".format(s)
+        raise argparse.ArgumentTypeError(msg)
 
 def is_azure_creds(creds):
     if 'azuredatabricks.net' in creds['host']:
@@ -234,7 +242,11 @@ def get_export_parser():
     parser.add_argument('--retry-total', type=int, default=3, help='Total number or retries when making calls to Databricks API')
 
     parser.add_argument('--retry-backoff', type=float, default=1.0, help='Backoff factor to apply between retry attempts when making calls to Databricks API')
-    
+
+    parser.add_argument('--start-date', action='store', default=None,
+                        help='start-date format: YYYY-MM-DD. If not provided, defaults to past 30 days. Currently, only used for exporting ML runs objects.',
+                        type=valid_date)
+
     return parser
 
 
@@ -517,4 +529,7 @@ def get_pipeline_parser() -> argparse.ArgumentParser:
 
     parser.add_argument('--retry-backoff', type=float, default=1.0, help='Backoff factor to apply between retry attempts when making calls to Databricks API')
 
+    parser.add_argument('--start-date', action='store', default=None,
+                        help='start-date format: YYYY-MM-DD. If not provided, defaults to past 30 days. Currently, only used for exporting ML runs objects.',
+                        type=valid_date)
     return parser

--- a/export_db.py
+++ b/export_db.py
@@ -299,7 +299,7 @@ def main():
     if args.mlflow_runs:
         print("Exporting MLflow runs.")
         mlflow_c = MLFlowClient(client_config, checkpoint_service)
-        mlflow_c.export_mlflow_runs(num_parallel=args.num_parallel)
+        mlflow_c.export_mlflow_runs(args.start_date, num_parallel=args.num_parallel)
         failed_task_log = logging_utils.get_error_log_file(wmconstants.WM_EXPORT, wmconstants.MLFLOW_RUN_OBJECT, client_config['export_dir'])
         logging_utils.raise_if_failed_task_file_exists(failed_task_log, "MLflow Runs Export.")
 
@@ -319,6 +319,8 @@ def main():
                 print("Error: %s - %s." % (e.filename, e.strerror))
         end = timer()
         print("Completed cleanup: " + str(timedelta(seconds=end - start)))
+
+
 
 
 if __name__ == '__main__':

--- a/export_db.py
+++ b/export_db.py
@@ -321,7 +321,5 @@ def main():
         print("Completed cleanup: " + str(timedelta(seconds=end - start)))
 
 
-
-
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Provides --start-date flag to --mlflow-runs export command line.
With the flag, it will only export the runs that are >= --start-date value.

Confirmed that indeed only the >= start_date runs are exported, by importing the exported runs to dst workspace
```
python3 export_db.py --profile mwc_src --mlflow-runs --start-date 2022-03-24
python3 import_db.py --profile mwc_dst --src-profile mwc_src --mlflow-runs --use-checkpoint --num-parallel 4
```

If the --start-date is not passed, 2015-01-01 is used as default value.
```
python3 export_db.py --profile mwc_src --mlflow-runs
```

Please review the last commit only: https://github.com/databrickslabs/migrate/pull/151/commits/b700f82edae6415a574ee0213b9fe9aa14745aa5