### PR TITLE
Import_workspace_acl should not be called in parallel.

### DIFF
--- a/dbclient/WorkspaceClient.py
+++ b/dbclient/WorkspaceClient.py
@@ -587,7 +587,7 @@ class WorkspaceClient(dbclient):
         return
 
     def import_workspace_acls(self, workspace_log_file='acl_notebooks.log',
-                              dir_log_file='acl_directories.log', num_parallel=4):
+                              dir_log_file='acl_directories.log', num_parallel=1):
         """
         import the notebook and directory acls by looping over notebook and dir logfiles
         """

--- a/import_db.py
+++ b/import_db.py
@@ -83,7 +83,8 @@ def main():
         ws_c = WorkspaceClient(client_config, checkpoint_service)
         start = timer()
         # log notebooks and libraries
-        ws_c.import_workspace_acls(num_parallel=args.num_parallel)
+        # Workspace Acl Import cannot handle parallel APIs due to the heavy loads.
+        ws_c.import_workspace_acls(num_parallel=1)
         end = timer()
         print("Complete Workspace acl Import Time: " + str(timedelta(seconds=end - start)))
 

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -158,7 +158,8 @@ class WorkspaceACLImportTask(AbstractTask):
 
     def run(self):
         ws_c = WorkspaceClient(self.client_config, self.checkpoint_service)
-        ws_c.import_workspace_acls(num_parallel=self.client_config["num_parallel"])
+        # Workspace Acl Import cannot handle parallel APIs due to the heavy loads.
+        ws_c.import_workspace_acls(num_parallel=1)
 
 
 class NotebookImportTask(AbstractTask):


### PR DESCRIPTION
Databricks ACL teams have reported that parallel import for workspace ACL can cause issues to the backed services. For now, we need to disable parallel feature for workspace ACL import until further scale out / rate limit is implemented in the Databricks backend service.