### PR TITLE
[Issue 138] Fix job format validation in `get_jobs_list()`

### DIFF
--- a/dbclient/JobsClient.py
+++ b/dbclient/JobsClient.py
@@ -41,7 +41,7 @@ class JobsClient(ClustersClient):
             for job in res.get('jobs', []):
                 jobId = job.get('job_id')
                 # only replaces "real" MULTI_TASK jobs, as they contain the task definitions.
-                if jobsById[jobId].get('format') == 'MULTI_TASK':
+                if jobsById[jobId].get('settings',{}).get('format') == 'MULTI_TASK':
                     jobsById[jobId] = job
         return jobsById.values()
 


### PR DESCRIPTION
Faced a similar issue as reported in https://github.com/databrickslabs/migrate/issues/138 where `MULTI_TASK` jobs are being imported without any/single task. While analyzing the issue could see there is a bug in fetching the job format and always takes `None`.

![image](https://user-images.githubusercontent.com/86963944/181124220-4af65146-3c41-446a-87b8-6645ab6c2593.png)

Above screenshot for reference.
Manually tested. Feel free to make any changes if required.

`jobs.log` BEFORE changes:
```
{
    "job_id": 493814031451245,
    "creator_user_name": "ravirahul.padmanabhan@databricks.com",
    "settings": {
        "name": "test_job:::493814031451245",
        "email_notifications": {
            "no_alert_for_skipped_runs": false
        },
        "timeout_seconds": 0,
        "max_concurrent_runs": 1,
        "format": "MULTI_TASK"
    },
    "created_time": 1658869379702
}
```

`jobs.log` AFTER changes:
```
{
    "job_id": 493814031451245,
    "creator_user_name": "ravirahul.padmanabhan@databricks.com",
    "settings": {
        "name": "test_job:::493814031451245",
        "email_notifications": {
            "no_alert_for_skipped_runs": false
        },
        "timeout_seconds": 0,
        "max_concurrent_runs": 1,
        "tasks": [
            {
                "task_key": "test_task_1",
                "notebook_task": {
                    "notebook_path": "/Event Log Replay",
                    "source": "WORKSPACE"
                },
                "job_cluster_key": "test_task_1_cluster",
                "timeout_seconds": 0,
                "email_notifications": {}
            },
            {
                "task_key": "test_task_2",
                "depends_on": [
                    {
                        "task_key": "test_task_1"
                    }
                ],
                "notebook_task": {
                    "notebook_path": "/Event Log Replay",
                    "source": "WORKSPACE"
                },
                "job_cluster_key": "test_task_1_cluster",
                "timeout_seconds": 0,
                "email_notifications": {}
            }
        ],
        "job_clusters": [
            {
                "job_cluster_key": "test_task_1_cluster",
                "new_cluster": {
                    "cluster_name": "",
                    "spark_version": "10.4.x-scala2.12",
                    "spark_conf": {
                        "spark.databricks.delta.preview.enabled": "true",
                        "spark.master": "local[*, 4]",
                        "spark.databricks.cluster.profile": "singleNode"
                    },
                    "azure_attributes": {
                        "first_on_demand": 1,
                        "availability": "ON_DEMAND_AZURE",
                        "spot_bid_max_price": -1.0
                    },
                    "node_type_id": "Standard_DS3_v2",
                    "custom_tags": {
                        "ResourceClass": "SingleNode"
                    },
                    "spark_env_vars": {
                        "PYSPARK_PYTHON": "/databricks/python3/bin/python3"
                    },
                    "enable_elastic_disk": true,
                    "runtime_engine": "STANDARD",
                    "num_workers": 0
                }
            }
        ],
        "format": "MULTI_TASK"
    },
    "created_time": 1658869379702
}
```

