### PR TITLE
Added logging of job id mapping

### DIFF
--- a/dbclient/JobsClient.py
+++ b/dbclient/JobsClient.py
@@ -110,9 +110,10 @@ class JobsClient(ClustersClient):
                     job_perms['job_name'] = new_job_name
                     acl_fp.write(json.dumps(job_perms) + '\n')
 
-    def import_job_configs(self, log_file='jobs.log', acl_file='acl_jobs.log'):
+    def import_job_configs(self, log_file='jobs.log', acl_file='acl_jobs.log', job_map_file='job_map.log'):
         jobs_log = self.get_export_dir() + log_file
         acl_jobs_log = self.get_export_dir() + acl_file
+        job_map_log = self.get_export_dir() + job_map_file
         error_logger = logging_utils.get_error_logger(
             wmconstants.WM_IMPORT, wmconstants.JOB_OBJECT, self.get_export_dir())
         if not os.path.exists(jobs_log):
@@ -147,7 +148,7 @@ class JobsClient(ClustersClient):
                     new_cluster_conf = cluster_conf
                 settings['new_cluster'] = new_cluster_conf
 
-        with open(jobs_log, 'r') as fp:
+        with open(jobs_log, 'r') as fp, open(job_map_log, 'w') as jm_fp:
             for line in fp:
                 job_conf = json.loads(line)
                 # need to do str(...), otherwise the job_id is recognized as integer which becomes
@@ -184,6 +185,8 @@ class JobsClient(ClustersClient):
                 else:
                     if 'job_id' in job_conf:
                         checkpoint_job_configs_set.write(job_conf["job_id"])
+                    _job_map = {job_conf["job_id"]: str(create_resp["job_id"])}
+                    jm_fp.write(json.dumps(_job_map) + '\n')
 
 
         # update the jobs with their ACLs

--- a/dbclient/dbclient.py
+++ b/dbclient/dbclient.py
@@ -362,7 +362,7 @@ class dbclient:
         log_dir = self.get_export_dir()
         logs_to_update = ['users.log',
                           'instance_profiles.log', 'clusters.log', 'cluster_policies.log',
-                          'jobs.log']
+                          'jobs.log', 'job_map.log']
         # update individual logs first
         for log_name in logs_to_update:
             if os.path.exists(log_dir + log_name):


### PR DESCRIPTION
Currently, the jobs ids do not get preserved when migrating. This change adds a log containing a mapping between job ids in the old workspace to job ids in the new workspace.