### PR TITLE
Job pausing

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,8 @@ usage: import_db.py [-h] [--users] [--workspace] [--workspace-top-level]
                     [--profile PROFILE] [--single-user SINGLE_USER]
                     [--no-ssl-verification] [--silent] [--debug]
                     [--set-export-dir SET_EXPORT_DIR] [--pause-all-jobs]
-                    [--unpause-all-jobs] [--delete-all-jobs]
+                    [--unpause-all-jobs] [--import-pause-status]
+                    [--delete-all-jobs]
                                         
 Import full workspace artifacts into Databricks
 
@@ -374,6 +375,7 @@ optional arguments:
                         export dir was a customized
   --pause-all-jobs      Pause all scheduled jobs
   --unpause-all-jobs    Unpause all scheduled jobs
+  --import-pause-status Import the pause status from jobs in the old workspace
   --delete-all-jobs     Delete all jobs
 ```
 
@@ -496,6 +498,11 @@ python export_db.py --profile DEMO --pause-all-jobs
 Un-pause all jobs in the new workspace:
 ```bash
 python import_db.py --profile NEW_DEMO --unpause-all-jobs
+```
+
+If you want to unpause only the jobs which were not paused in the old workspace, you can use the following option:
+```bash
+python import_db.py --profile NEW_DEMO --import-pause-status
 ```
 
 ### Hive Metastore

--- a/dbclient/JobsClient.py
+++ b/dbclient/JobsClient.py
@@ -110,7 +110,7 @@ class JobsClient(ClustersClient):
                     job_perms['job_name'] = new_job_name
                     acl_fp.write(json.dumps(job_perms) + '\n')
 
-    def import_job_configs(self, log_file='jobs.log', acl_file='acl_jobs.log', job_map_file='job_map.log'):
+    def import_job_configs(self, log_file='jobs.log', acl_file='acl_jobs.log', job_map_file='job_id_map.log'):
         jobs_log = self.get_export_dir() + log_file
         acl_jobs_log = self.get_export_dir() + acl_file
         job_map_log = self.get_export_dir() + job_map_file
@@ -185,7 +185,7 @@ class JobsClient(ClustersClient):
                 else:
                     if 'job_id' in job_conf:
                         checkpoint_job_configs_set.write(job_conf["job_id"])
-                    _job_map = {job_conf["job_id"]: str(create_resp["job_id"])}
+                    _job_map = {"old_id": job_conf["job_id"], "new_id": str(create_resp["job_id"])}
                     jm_fp.write(json.dumps(_job_map) + '\n')
 
 

--- a/dbclient/JobsClient.py
+++ b/dbclient/JobsClient.py
@@ -110,9 +110,10 @@ class JobsClient(ClustersClient):
                     job_perms['job_name'] = new_job_name
                     acl_fp.write(json.dumps(job_perms) + '\n')
 
-    def import_job_configs(self, log_file='jobs.log', acl_file='acl_jobs.log'):
+    def import_job_configs(self, log_file='jobs.log', acl_file='acl_jobs.log', job_map_file='job_map.log'):
         jobs_log = self.get_export_dir() + log_file
         acl_jobs_log = self.get_export_dir() + acl_file
+        job_map_log = self.get_export_dir() + job_map_file
         error_logger = logging_utils.get_error_logger(
             wmconstants.WM_IMPORT, wmconstants.JOB_OBJECT, self.get_export_dir())
         if not os.path.exists(jobs_log):
@@ -147,7 +148,7 @@ class JobsClient(ClustersClient):
                     new_cluster_conf = cluster_conf
                 settings['new_cluster'] = new_cluster_conf
 
-        with open(jobs_log, 'r') as fp:
+        with open(jobs_log, 'r') as fp, open(job_map_log, 'w') as jm_fp:
             for line in fp:
                 job_conf = json.loads(line)
                 # need to do str(...), otherwise the job_id is recognized as integer which becomes
@@ -184,6 +185,8 @@ class JobsClient(ClustersClient):
                 else:
                     if 'job_id' in job_conf:
                         checkpoint_job_configs_set.write(job_conf["job_id"])
+                    _job_map = {job_conf["job_id"]: str(create_resp["job_id"])}
+                    jm_fp.write(json.dumps(_job_map) + '\n')
 
 
         # update the jobs with their ACLs

--- a/dbclient/dbclient.py
+++ b/dbclient/dbclient.py
@@ -362,7 +362,7 @@ class dbclient:
         log_dir = self.get_export_dir()
         logs_to_update = ['users.log',
                           'instance_profiles.log', 'clusters.log', 'cluster_policies.log',
-                          'jobs.log', 'job_map.log']
+                          'jobs.log', 'job_id_map.log']
         # update individual logs first
         for log_name in logs_to_update:
             if os.path.exists(log_dir + log_name):

--- a/dbclient/dbclient.py
+++ b/dbclient/dbclient.py
@@ -362,7 +362,7 @@ class dbclient:
         log_dir = self.get_export_dir()
         logs_to_update = ['users.log',
                           'instance_profiles.log', 'clusters.log', 'cluster_policies.log',
-                          'jobs.log']
+                          'jobs.log', 'job_map.log']
         # update individual logs first
         for log_name in logs_to_update:
             if os.path.exists(log_dir + log_name):

--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -388,6 +388,9 @@ def get_import_parser():
     parser.add_argument('--unpause-all-jobs', action='store_true',
                         help='Unpause all scheduled jobs')
 
+    parser.add_argument('--import-pause-status', action='store_true',
+                        help='Imports pause status for migrated jobs')
+
     parser.add_argument('--delete-all-jobs', action='store_true',
                         help='Delete all jobs')
 

--- a/import_db.py
+++ b/import_db.py
@@ -173,6 +173,16 @@ def main():
         jobs_c.pause_all_jobs(False)
         end = timer()
         print("Unpaused all jobs time: " + str(timedelta(seconds=end - start)))
+    
+    if args.import_pause_status:
+        print("Importing pause status for migrated jobs {0}".format(now))
+        start = timer()
+        jobs_c = JobsClient(client_config, checkpoint_service)
+        # log job configs
+        jobs_c.import_pause_status()
+        end = timer()
+        print("Import pause jobs time: " + str(timedelta(seconds=end - start)))
+
 
     if args.delete_all_jobs:
         print("Delete all current jobs {0}".format(now))


### PR DESCRIPTION
This pull request adds two functionalities:

- adds a log containing a mapping between job ids in the old workspace to job ids in the new workspace. This is in the same format as the log id mapping used for mlflow experiments
- adds functionality to unpause only jobs with schedules which are not paused in the source workspace - see issue [196](https://github.com/databrickslabs/migrate/issues/196)