### PR TITLE
Fix JobSettings format key

### DIFF
--- a/dbclient/JobsClient.py
+++ b/dbclient/JobsClient.py
@@ -41,7 +41,7 @@ class JobsClient(ClustersClient):
             for job in res.get('jobs', []):
                 jobId = job.get('job_id')
                 # only replaces "real" MULTI_TASK jobs, as they contain the task definitions.
-                if jobsById[jobId].get('format') == 'MULTI_TASK':
+                if jobsById[jobId]['settings'].get('format') == 'MULTI_TASK':
                     jobsById[jobId] = job
         return jobsById.values()
 


### PR DESCRIPTION
Fixing [#206 JobsClient does not export tasks for MULTI_TASK jobs](https://github.com/databrickslabs/migrate/issues/206)

The current code is accessing `format` in the root of the response, however the following doc shows `format` is nested in `settings`:

- https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsGet (example response returns `format` in `settings)

Note: The above linked doc is related to API v2.1. However, I tested both v2.0 and v2.1, and both returns `format` in `settings`. (Unfortunately, v2.0 documentation does not mention `format` at all.) 

As reported in the issue, no tasks were returned for MULTI_TASK jobs before. After this change, tasks are returned as expected.
