### PR TITLE
Including --gcp option and updated GCP cluster definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The recommended method of exporting and importing is by using the Pipeline conta
 
 ```
 python migration_pipeline.py -h
-usage: migration_pipeline.py [-h] [--profile PROFILE] [--azure] [--silent] [--no-ssl-verification] [--debug] [--set-export-dir SET_EXPORT_DIR]
+usage: migration_pipeline.py [-h] [--profile PROFILE] [--azure or gcp] [--silent] [--no-ssl-verification] [--debug] [--set-export-dir SET_EXPORT_DIR]
                              [--cluster-name CLUSTER_NAME] [--notebook-format {DBC,SOURCE,HTML}] [--overwrite-notebooks] [--archive-missing]
                              [--repair-metastore-tables] [--metastore-unicode] [--skip-failed] [--session SESSION] [--dry-run] [--export-pipeline] [--import-pipeline]
                              [--validate-pipeline] [--validate-source-session VALIDATE_SOURCE_SESSION] [--validate-destination-session VALIDATE_DESTINATION_SESSION]
@@ -130,7 +130,7 @@ Export user(s) workspace artifacts from Databricks
 optional arguments:
   -h, --help            show this help message and exit
   --profile PROFILE     Profile to parse the credentials
-  --azure               Run on Azure. (Default is AWS)
+  --azure or gcp        Run on Azure or GCP. (Default is AWS)
   --silent              Silent all logging of export operations.
   --no-ssl-verification
                         Set Verify=False when making http requests.

--- a/data/default_jobs_cluster_gcp.json
+++ b/data/default_jobs_cluster_gcp.json
@@ -1,0 +1,8 @@
+{
+  "num_workers": 8,
+  "spark_version": "7.3.x-scala2.12",
+  "node_type_id": "n1-highmem-4",
+  "spark_env_vars": {
+    "PYSPARK_PYTHON": "/databricks/python3/bin/python3"
+  }
+}

--- a/data/gcp_cluster.json
+++ b/data/gcp_cluster.json
@@ -1,0 +1,14 @@
+{
+  "num_workers": 1,
+  "cluster_name": "Workspace_Migration_Work_Leave_Me_Alone",
+  "spark_version": "10.4.x-scala2.12",
+  "gcp_attributes": {
+    "first_on_demand": 1
+  },
+  "driver_node_type_id": "n1-highmem-4",
+  "node_type_id": "n1-highmem-4",
+  "spark_env_vars": {
+    "PYSPARK_PYTHON": "/databricks/python3/bin/python3"
+  },
+  "autotermination_minutes": 15
+}

--- a/data/gcp_cluster_table_acls.json
+++ b/data/gcp_cluster_table_acls.json
@@ -1,0 +1,27 @@
+{
+  "cluster_name": "API_Table_ACL_Work_Leave_Me_Alone",
+  "spark_version": "10.4.x-scala2.12",
+  "spark_conf": {
+    "spark.databricks.cluster.profile": "serverless",
+    "spark.databricks.cluster.profile":"singleNode",
+    "spark.databricks.acl.dfAclsEnabled": "true",
+    "spark.databricks.pyspark.enablePy4JSecurity": "false",
+    "spark.sql.hive.metastore.version": "1.2.1",
+    "spark.sql.hive.metastore.jars": "maven"
+  },
+  "gcp_attributes": {
+    "use_preemptible_executors": false
+  },
+  "node_type_id": "n1-highmem-4",
+  "driver_node_type_id": "n1-highmem-4",
+  "ssh_public_keys": [],
+  "custom_tags": {},
+  "spark_env_vars": {
+    "PYSPARK_PYTHON": "/databricks/python3/bin/python3"
+  },
+  "autotermination_minutes": 15,
+  "enable_elastic_disk": false,
+  "cluster_source": "API",
+  "init_scripts": [],
+  "num_workers": 1
+}

--- a/data/workspace_migration_analysis.py
+++ b/data/workspace_migration_analysis.py
@@ -32,6 +32,12 @@ class dbclient:
     def is_aws(self):
         return self._is_aws
 
+    def is_azure(self):
+        return self._is_azure
+
+    def is_gcp(self):
+        return self._is_gcp
+
     def is_verbose(self):
         return self._is_verbose
 

--- a/dbclient/ClustersClient.py
+++ b/dbclient/ClustersClient.py
@@ -482,8 +482,11 @@ class ClustersClient(dbclient):
                 print("Creating cluster with: " + iam_role)
                 aws_attr['instance_profile_arn'] = iam_role
                 cluster_json['aws_attributes'] = aws_attr
-        else:
+        elif self.is_azure():
             with open(f'{real_path}/../data/azure_cluster{cluster_json_postfix}.json', 'r') as fp:
+                cluster_json = json.loads(fp.read())
+        elif self.is_gcp():
+            with open(f'{real_path}/../data/gcp_cluster{cluster_json_postfix}.json', 'r') as fp:
                 cluster_json = json.loads(fp.read())
         # set the latest spark release regardless of defined cluster json
         # cluster_json['spark_version'] = version['key']
@@ -497,7 +500,7 @@ class ClustersClient(dbclient):
             logging.info("Starting cluster with name: {0} ".format(cluster_name))
             c_info = self.post('/clusters/create', cluster_json)
             if c_info['http_status_code'] != 200:
-                raise Exception("Could not launch cluster. Verify that the --azure flag or cluster config is correct.")
+                raise Exception("Could not launch cluster. Verify that the --azure or --gcp flag or cluster config is correct.")
             self.wait_for_cluster(c_info['cluster_id'])
             return c_info['cluster_id']
 

--- a/dbclient/JobsClient.py
+++ b/dbclient/JobsClient.py
@@ -9,8 +9,10 @@ class JobsClient(ClustersClient):
     def get_jobs_default_cluster_conf(self):
         if self.is_aws():
             cluster_json_file = 'data/default_jobs_cluster_aws.json'
-        else:
+        elif self.is_azure():
             cluster_json_file = 'data/default_jobs_cluster_azure.json'
+        elif self.is_gcp():
+            cluster_json_file = 'data/default_jobs_cluster_gcp.json'
         with open(cluster_json_file, 'r') as fp:
             cluster_json = json.loads(fp.read())
             return cluster_json

--- a/dbclient/dbclient.py
+++ b/dbclient/dbclient.py
@@ -57,6 +57,8 @@ class dbclient:
         self._update_token(configs['token'])
         self._export_dir = configs['export_dir']
         self._is_aws = configs['is_aws']
+        self._is_azure = configs['is_azure']
+        self._is_gcp = configs['is_gcp']
         self._skip_failed = configs['skip_failed']
         self._is_verbose = configs['verbose']
         self._verify_ssl = configs['verify_ssl']
@@ -82,6 +84,12 @@ class dbclient:
 
     def is_aws(self):
         return self._is_aws
+
+    def is_azure(self):
+        return self._is_azure
+
+    def is_gcp(self):
+        return self._is_gcp
 
     def is_verbose(self):
         return self._is_verbose

--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -467,7 +467,7 @@ def build_client_config(profile, url, token, args):
     elif config['is_aws']:
         config['export_dir'] = 'logs/'
     elif config['is_azure']:
-        config['export_dir'] = 'azure_logs'
+        config['export_dir'] = 'azure_logs/'
     else:
         config['export_dir'] = 'gcp_logs/'
 

--- a/export_db.py
+++ b/export_db.py
@@ -18,8 +18,11 @@ def main():
 
     # parse the path location of the Databricks CLI configuration
     login_args = get_login_credentials(profile=args.profile)
-    if is_azure_creds(login_args) and (not args.azure):
+    if is_azure_creds(login_args) and (not args.azure) :
         raise ValueError('Login credentials do not match args. Please provide --azure flag for azure envs.')
+
+    if is_gcp_creds(login_args) and (not args.gcp) :
+        raise ValueError('Login credentials do not match args. Please provide --gcp flag for gcp envs.')
 
     # cant use netrc credentials because requests module tries to load the credentials into http basic auth headers
     # parse the credentials
@@ -93,7 +96,7 @@ def main():
 
     if args.libs:
         if not client_config['is_aws']:
-            print("Databricks does not support library exports on Azure today")
+            print("Databricks does not support library exports on Azure or GCP today")
         else:
             print("Starting complete library log at {0}".format(now))
             lib_c = LibraryClient(client_config)

--- a/import_db.py
+++ b/import_db.py
@@ -18,6 +18,9 @@ def main():
     if is_azure_creds(login_args) and (not args.azure):
         raise ValueError('Login credentials do not match args. Please provide --azure flag for azure environments.')
 
+    if is_gcp_creds(login_args) and (not args.gcp):
+        raise ValueError('Login credentials do not match args. Please provide --gcp flag for gcp environments.')
+
     # cant use netrc credentials because requests module tries to load the credentials into http basic auth headers
     url = login_args['host']
     token = login_args['token']

--- a/migration_pipeline.py
+++ b/migration_pipeline.py
@@ -27,9 +27,14 @@ def build_pipeline(args) -> Pipeline:
         client_config = parser.build_client_config_without_profile(args)
     else:
         login_args = parser.get_login_credentials(profile=args.profile)
+
         if parser.is_azure_creds(login_args) and (not args.azure):
             raise ValueError(
                 'Login credentials do not match args. Please provide --azure flag for azure envs.')
+
+        if parser.is_gcp_creds(login_args) and (not args.gcp):
+            raise ValueError(
+                'Login credentials do not match args. Please provide --gcp flag for gcp envs.')
 
         # Cant use netrc credentials because requests module tries to load the credentials into http
         # basic auth headers parse the credentials


### PR DESCRIPTION
Hi,

I'm including some changes to be able to work with GCP as we have the api's and cli working with GCP (experimental mode). Even that is experimental this will help in the future and also some Databricks gcp customers that needs to migrate assets between different workspaces

The work performed was:

0 - Generate gcp flag

1 - Separate aws, azure and gcp flags (is_aws, is_azure and is_gcp). The logic was looking only for azure flag and if it was null the is_aws was valid. 
I've included the is_azure and is_gcp to remove this logic and is_aws is valid if is_gcp and is azure are null. Maybe in the future include the aws flag is a good option. *TODO*

2 - This allowed to define that if a cluster isn't aws or azure, it will use a gcp template to create a cluster in GCP using the cluster creation function

3 - Included GCP templates

In the tests that I've made this allowed me to export with this change jobs , metastore and table acls from/to gcp workspaces.

*Bigquery tables created in the metastore had permission errors- *TODO* to verify what was wrong.

Thank you,

Luiz