### PR TITLE
Mutl task job and Instance pool cluster Fix

### DIFF
--- a/migration_pipeline.py
+++ b/migration_pipeline.py
@@ -253,7 +253,7 @@ def build_validate_pipeline(client_config, checkpoint_service, args):
     #  ClustersExportTask
     add_diff_task("validate-clusters", "clusters.log", DiffConfig(
         primary_key="cluster_name",
-        ignored_keys=["cluster_id", "policy_id", "instance_pool_id", "spark_version"],
+        ignored_keys=["cluster_id", "policy_id", "instance_pool_id", "driver_instance_pool_id", "spark_version"],
         children={
             "aws_attributes": DiffConfig(
                 ignored_keys=["zone_id"]


### PR DESCRIPTION
Changes included.

1. Fix for expired Instance Pool handling in cluster import.
2. Added optional driver_instance_pool_id key handling with instance pool clusters as per https://docs.databricks.com/dev-tools/api/latest/clusters.html#request-structure-of-the-cluster-definition 
3. Fixed multi-task job setting for cluster configuration.
- task level setting may have new_cluster/existing_cluster or job_cluster_key for shared job clusters.