### PR TITLE
Fix cluster OriginalCreator tag value and check 'new_cluster' config exists in task

### DIFF
--- a/dbclient/ClustersClient.py
+++ b/dbclient/ClustersClient.py
@@ -270,10 +270,10 @@ class ClustersClient(dbclient):
                     # add original creator tag to help with DBU tracking
                     if 'custom_tags' in cluster_conf:
                         tags = cluster_conf['custom_tags']
-                        tags['OriginalCreator'] = cluster_creator
+                        tags['OriginalCreator'] = self.normalize_tag_value(cluster_creator)
                         cluster_conf['custom_tags'] = tags
                     else:
-                        cluster_conf['custom_tags'] = {'OriginalCreator': cluster_creator}
+                        cluster_conf['custom_tags'] = {'OriginalCreator': self.normalize_tag_value(cluster_creator)}
                     new_cluster_conf = cluster_conf
                 print("Creating cluster: {0}".format(new_cluster_conf['cluster_name']))
                 cluster_resp = self.post('/clusters/create', new_cluster_conf)
@@ -741,3 +741,5 @@ class ClustersClient(dbclient):
             raise RuntimeError("Cluster is terminated. Please check EVENT history for details")
         return cid
 
+    def normalize_tag_value(self, value: str):
+        return value.replace("@", "_at_")

--- a/dbclient/JobsClient.py
+++ b/dbclient/JobsClient.py
@@ -148,7 +148,7 @@ class JobsClient(ClustersClient):
                     settings['new_cluster'] = self.get_jobs_default_cluster_conf()
                 else:
                     settings['existing_cluster_id'] = new_cid
-            else:  # new cluster config
+            elif 'new_cluster' in settings:  # new cluster config
                 cluster_conf = settings['new_cluster']
                 if 'policy_id' in cluster_conf:
                     old_policy_id = cluster_conf['policy_id']


### PR DESCRIPTION
This PR tent to fix 2 issues

### Cluster tag value not allow special character

The custom tag when create cluster doesn't allow special character, but the script is using email address for the `OriginalCreator` tag, which contains `@` and cause error

The PR replace the `@` with `_at_`

### `new_cluster` not exists in task settings
The script default get the new_cluster config if there is no `existing_cluster_id` in settings, but the `new_cluster` key is optional.

The PR check the `new_cluster` to make sure it exists before using it.