### PR TITLE
feat: add service principal option to ACLs

### DIFF
--- a/dbclient/dbclient.py
+++ b/dbclient/dbclient.py
@@ -334,6 +334,9 @@ class dbclient:
                                   'permission_level': permissions})
                 if permissions == 'IS_OWNER':
                     current_owner = member.get('user_name')
+            elif 'service_principal_name' in member:
+                acls_list.append({'service_principal_name': member.get('service_principal_name'),
+                                  'permission_level': permissions})
             else:
                 if member.get('group_name') != 'admins':
                     acls_list.append({'group_name': member.get('group_name'),


### PR DESCRIPTION
This feat adds support for generating ACLs args for service principals, in aggregation to the already supported user & group support.

**Current behaviour**

Given a ACL Json with permissions around a service_principal,

When attempts to attach the object name and permissions,

Then an KeyError raises at attempting to search for the key "group_name" in the `else` block


**Expected behaviour**

Given a ACL Json with permissions around a service_principal,

When attempts to attach the object name and permissions,

Then it maps properly the service principal name and its permissions