### PR TITLE
import updated and new notebooks only

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ usage: import_db.py [-h] [--users] [--workspace] [--workspace-top-level]
                     [--no-ssl-verification] [--silent] [--debug]
                     [--set-export-dir SET_EXPORT_DIR] [--pause-all-jobs]
                     [--unpause-all-jobs] [--import-pause-status]
-                    [--delete-all-jobs]
+                    [--delete-all-jobs] [--last-session]
                                         
 Import full workspace artifacts into Databricks
 
@@ -389,6 +389,8 @@ optional arguments:
   --unpause-all-jobs    Unpause all scheduled jobs
   --import-pause-status Import the pause status from jobs in the old workspace
   --delete-all-jobs     Delete all jobs
+  --last-session        
+                        The session to compare against. If set, the script compares current sesssion with the last session and only import updated and new notebooks. 
 ```
 
 ---

--- a/dbclient/common/WorkspaceDiff.py
+++ b/dbclient/common/WorkspaceDiff.py
@@ -1,0 +1,76 @@
+import os
+from filecmp import cmpfiles, dircmp
+import pathlib
+from typing import Set
+
+
+def get_dir_files(dir: str):
+    files = []
+    for obj in pathlib.Path(dir).rglob("*"):
+        if os.path.isfile(obj):
+            files.append(str(obj))
+    return files
+
+def get_updated_new_files(dir1: str, dir2: str):
+    """ 
+    Compare old artifacts directory and current artifacts directory 
+    and return all noteboooks that have been updated or newly added to the notebook_changes.log file.
+    :param dir1: old artifacts directory
+    :param dir2: new artifacts directory
+    """
+    changed_files = []
+    dcmp = dircmp(dir1, dir2)
+    for file in dcmp.diff_files:
+        changed_files.append(os.path.join(dir2, file))
+    for obj in dcmp.right_only:
+        objpath = os.path.join(dir2, obj)
+        if os.path.isdir(objpath):
+            new_files = get_dir_files(objpath)
+            changed_files += new_files
+    for obj in dcmp.common_dirs:
+        tmp_files = get_updated_new_files(os.path.join(dir1, obj), os.path.join(dir2, obj))
+        changed_files += tmp_files
+    
+    return set(changed_files)
+
+
+def log_updated_new_files(dir1: str, dir2: str, logfile):
+    """ 
+    Compare old artifacts directory and current artifacts directory 
+    and log all noteboooks that have been updated or newly added to the notebook_changes.log file.
+    :param dir1: old artifacts directory
+    :param dir2: new artifacts directory
+    :param logfile: file pointer of the notebook_changes.log
+    """
+    dcmp = dircmp(dir1, dir2)
+    for file in dcmp.diff_files:
+        logfile.write(os.path.join(dir2, file) + "\n")
+    for obj in dcmp.right_only:
+        objpath = os.path.join(dir2, obj)
+        if os.path.isdir(objpath):
+            new_files = get_dir_files(objpath)
+            logfile.writelines(new_files)
+                
+    for obj in dcmp.common_dirs:
+        log_updated_new_files(os.path.join(dir1, obj), os.path.join(dir2, obj), logfile)
+    
+    return None
+
+def log_file_changes(changes_since_last: Set[str], log_file):
+    """
+    Log the set of file names to a log file.
+    """
+    if not changes_since_last: return None
+
+    with open(log_file, "w") as fp:
+        for changed_file in changes_since_last:
+            fp.write(changed_file + "\n")
+
+def read_file_changes(log_file):
+    """
+    Read file names from a log file.
+    """
+    with open(log_file, "r") as fp:
+        changed_files = fp.readlines()
+        return set(changed_files)
+    

--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -557,4 +557,7 @@ def get_pipeline_parser() -> argparse.ArgumentParser:
     parser.add_argument('--timeout', type=float, default=300.0,
                         help='Timeout for the calls to Databricks\' REST API, in seconds, defaults to 300.0 --use float e.g. 100.0 to make it bigger')
 
+    parser.add_argument('--last-session', action='store', default='',
+                        help='If set, the script compares current sesssion with the last session and only import updated and new notebooks.')
+
     return parser

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -182,7 +182,8 @@ class NotebookImportTask(AbstractTask):
                 raise ValueError(
                     'Overwrite notebooks only supports the SOURCE format. See Rest API docs for details')
         ws_c.import_all_workspace_items(archive_missing=self.args.archive_missing,
-                                        num_parallel=self.client_config["num_parallel"])
+                                        num_parallel=self.client_config["num_parallel"],
+                                        last_session=self.args.last_session)
         ws_c.import_all_repos(num_parallel=self.client_config["num_parallel"])
 
 


### PR DESCRIPTION
Added an option to import notebooks incrementally.

--last-session will define a previous session to compare with the current session. All updated and newly added notebooks will be logged in notebook_changes.log. A set of updated and new notebooks will be created in memory. Only these notebooks will be imported skipping other unchanged notebook.

This is a feature useful when there is a large number of artifacts and we are only interested in importing what has been changed.