### PR TITLE
improve incremental notebook import by loading diff in memory and log all together

### DIFF
--- a/dbclient/WorkspaceClient.py
+++ b/dbclient/WorkspaceClient.py
@@ -820,14 +820,13 @@ class WorkspaceClient(dbclient):
                                                       self.get_export_dir())
         
         # Given previous exported artifacts, a list of changed and newly added notebooks will be logged at notebook_changes.log
-        nb_changes_log = os.path.join(self.get_export_dir(), "notebook_changes.log")
         changes_since_last = set()
         if last_session:
+            nb_changes_log = os.path.join(self.get_export_dir(), "notebook_changes.log")
             base_dir = os.path.split(os.path.normpath(self.get_export_dir()))[0]
             last_src_dir = os.path.join(base_dir, last_session, artifact_dir)
-            with open(nb_changes_log, "w") as fp:
-                log_updated_new_files(last_src_dir, src_dir, fp)
-            changes_since_last = read_file_changes(nb_changes_log)
+            changes_since_last = get_updated_new_files(last_src_dir, src_dir)
+            log_file_changes(changes_since_last, nb_changes_log)
 
         checkpoint_notebook_set = self._checkpoint_service.get_checkpoint_key_set(
             wmconstants.WM_IMPORT, wmconstants.WORKSPACE_NOTEBOOK_OBJECT)


### PR DESCRIPTION
Improve incremental notebook import by recursively collecting new and updated notebooks in memory first and flush out to logs all together.

This also fixed issue of writing out multiple notebooks in a single line.