### PR TITLE
Update JobsClient.py to make sure all jobs are imported as PAUSED

### DIFF
--- a/dbclient/JobsClient.py
+++ b/dbclient/JobsClient.py
@@ -209,6 +209,13 @@ class JobsClient(ClustersClient):
                     # set all imported jobs as paused
                     job_schedule['pause_status'] = 'PAUSED'
                     job_settings['schedule'] = job_schedule
+                job_schedule_continuous = job_settings.get("continuous", None)
+                if job_schedule_continuous: 
+                    # set all import jobs as paused
+                    job_schedule_continuous['pause_status'] = "PAUSED" 
+                    job_settings['continuous'] = job_schedule_continuous
+                
+                    
                 if 'format' not in job_settings or job_settings.get('format') == 'SINGLE_TASK':
                     adjust_ids_for_cluster(job_settings)
                 else:


### PR DESCRIPTION
Problem: continuous (not scheduled) jobs were imported in an UNPAUSED state. 

Fixed this by switching them to a paused state during the import. 