### PR TITLE
Add new flag to auto lowercase exported user output

### DIFF
--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -78,6 +78,10 @@ def get_export_parser():
     parser.add_argument('--users', action='store_true',
                         help='Download all the users and groups in the workspace')
 
+    # convert all users to lowercase for SCIM API changes
+    parser.add_argument('--replace-email-auto', action='store_true',
+                        help='Modify exported user and related configuration with a lower case username, use after export and reference with --session $SESSION')
+
     # log all user workspace paths
     parser.add_argument('--workspace', action='store_true',
                         help='Log all the notebook paths in the workspace. (metadata only)')

--- a/export_db.py
+++ b/export_db.py
@@ -240,6 +240,21 @@ def main():
         end = timer()
         print("Complete email update time: " + str(timedelta(seconds=end - start)))
 
+    if args.replace_email_auto:
+        print("Automatically updating old email to new email address at {0}".format(now))
+        start = timer()
+        client = dbclient(client_config)
+        scim_c = ScimClient(client_config, checkpoint_service)
+        
+        users = scim_c.get_users_from_log()
+        # print("Updating {len(users)}...")
+        for u in users:
+            print(f"Updating '{u}' to '{u.lower()}'")
+            client.update_email_addresses(u, u.lower())
+
+        end = timer()
+        print("Complete email update time: " + str(timedelta(seconds=end - start)))
+
     if args.single_user:
         user_email = args.single_user
         print(f"Export user {user_email} at {now}")


### PR DESCRIPTION
SCIM API behavior has changed to automatically lowercase users, this creates issues for migrating users from workspaces where users were created before the changes. Adding a new flag to --replace-email-auto to automatically iterate through the logged users and run the replace_email function for each.
