### PR TITLE
Updated error message text when notebook size exceeds 10485760 bytes

### DIFF
--- a/dbclient/WorkspaceClient.py
+++ b/dbclient/WorkspaceClient.py
@@ -351,7 +351,7 @@ class WorkspaceClient(dbclient):
             logging_utils.log_response_error(error_logger, resp)
             return resp
         if resp.get('error_code', None):
-            if self.skip_large_nb and resp.get("message", None) == 'Size exceeds 10485760 bytes':
+            if self.skip_large_nb and re.search(r"Notebook size exceeded limit: \d+ > 10485760", resp.get("message", '')):
                 logging.info("Notebook {} skipped due to size exceeding limit".format(notebook_path))
             else:
                 resp['path'] = notebook_path


### PR DESCRIPTION
When attempting to download a notebook greater than 10485760 bytes in size, the API previously returned an error formatted as follows:

`{"error_code": "BAD_REQUEST", "message": "Size exceeds 10485760 bytes", "http_status_code": 400, "path": "/Users/xxx@xxx.com/xxx"}`

There appears to have been an update, such that the error is now formatted more along the lines of:

`{"error_code": "BAD_REQUEST", "message": "Notebook size exceeded limit: *(some file size)* > 10485760", "http_status_code": 400, "path": "/Users/xxx@xxx.com/xxx"}`

This PR updates WorkspaceClient.py to account for the update, to restore functionality provided by the `--skip-large-nb` flag