### PR TITLE
Add --skip-acls option for exporting.

### DIFF
--- a/dbclient/JobsClient.py
+++ b/dbclient/JobsClient.py
@@ -123,6 +123,12 @@ class JobsClient(ClustersClient):
                 # reset the original struct with the new settings
                 x['settings'] = job_settings
 
+                args = parser.get_pipeline_parser().parse_args()
+
+                if args.skip_acls:
+                    log_fp.write(json.dumps(x) + '\n')
+                    continue
+
                 # get ACLs and check that the job has one owner before writing
                 job_perms = self.get(f'/preview/permissions/jobs/{job_id}')
                 if not logging_utils.log_response_error(error_logger, job_perms):

--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -551,6 +551,9 @@ def get_pipeline_parser() -> argparse.ArgumentParser:
     parser.add_argument('--keep-tasks', nargs='+', type=str, action=ValidateSkipTasks, default=[],
                         help='List of tasks to run in the pipeline; overrides --skip-tasks.')
 
+    parser.add_argument('--skip-acls', action='store_true',
+                        help='Skip exporting ACLs whose absence may cause errors.')
+
     parser.add_argument('--num-parallel', type=int, default=4, help='Number of parallel threads to use to '
                                                                           'export/import')
 

--- a/migration_pipeline.py
+++ b/migration_pipeline.py
@@ -97,6 +97,12 @@ def build_export_pipeline(client_config, checkpoint_service, args) -> Pipeline:
     else:
         skip_tasks = args.skip_tasks
 
+    if args.skip_acls:
+        skip_tasks.append(wmconstants.WORKSPACE_ACLS)
+        skip_tasks.append(wmconstants.METASTORE_TABLE_ACLS)
+
+        skip_tasks = list(set(skip_tasks))
+
     source_info_file = os.path.join(client_config['export_dir'], "source_info.txt")
     with open(source_info_file, 'w') as f:
         f.write(client_config['url'])


### PR DESCRIPTION
Standard accounts do not support acls; as a result various errors are encountered when attempting to export.